### PR TITLE
[sp1-03] #TK-01082 request_detailにvalidate設定

### DIFF
--- a/app/controllers/request_details_controller.rb
+++ b/app/controllers/request_details_controller.rb
@@ -17,6 +17,7 @@ class RequestDetailsController < ApplicationController
     if @request_detail.save
       change_redirect_to_by_commit_message
     else
+      @request_application = @request_detail.request_application
       render :new
     end
   end
@@ -25,6 +26,7 @@ class RequestDetailsController < ApplicationController
     if @request_detail.update(request_detail_params)
       change_redirect_to_by_commit_message
     else
+      @request_application = @request_detail.request_application
       render :edit
     end
   end

--- a/app/models/request_detail.rb
+++ b/app/models/request_detail.rb
@@ -11,6 +11,7 @@ class RequestDetail < ActiveRecord::Base
 
   INVALID_REGEX = /\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々]|[Ａ-Ｚ]|[０-９]/
 
+  # TODO: rspecセットアップ後にvalidateのテストコードを書くこと
   %i(doc_no sht rev eo_chgno mcl scp_for_smpl scml_ln).each do |attribute|
     validates attribute, length: { maximum: 255 }, format: { without: INVALID_REGEX }
   end

--- a/app/models/request_detail.rb
+++ b/app/models/request_detail.rb
@@ -3,11 +3,15 @@ class RequestDetail < ActiveRecord::Base
   belongs_to :doc_type
   belongs_to :chg_type
 
-  validates :doc_no, length: { maximum: 255 }
-  validates :sht, length: { maximum: 255 }
-  validates :rev, length: { maximum: 255 }
-  validates :eo_chgno, length: { maximum: 255 }
-  validates :mcl, length: { maximum: 255 }
-  validates :scp_for_smpl, length: { maximum: 255 }
-  validates :scml_ln, length: { maximum: 255 }
+  before_validation do
+    %i(doc_no sht rev eo_chgno mcl scp_for_smpl scml_ln).each do |attribute|
+      send(attribute).upcase!
+    end
+  end
+
+  INVALID_REGEX = /\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々]/
+
+  %i(doc_no sht rev eo_chgno mcl scp_for_smpl scml_ln).each do |attribute|
+    validates attribute, length: { maximum: 255 }, format: { without: INVALID_REGEX }
+  end
 end

--- a/app/models/request_detail.rb
+++ b/app/models/request_detail.rb
@@ -9,7 +9,7 @@ class RequestDetail < ActiveRecord::Base
     end
   end
 
-  INVALID_REGEX = /\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々]/
+  INVALID_REGEX = /\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々]|[Ａ-Ｚ]|[０-９]/
 
   %i(doc_no sht rev eo_chgno mcl scp_for_smpl scml_ln).each do |attribute|
     validates attribute, length: { maximum: 255 }, format: { without: INVALID_REGEX }


### PR DESCRIPTION
・半角英字、半角数字、半角記号の入力が可能、かつ、
・英字は大文字のみ→システムで大文字に

・半角カナもOK

上記を踏まえてひらがなと漢字以外は登録できるようにしています。
認識が違っていたらすみません…