### PR TITLE
[sp2-03] #TK-01106 tsvファイルを読込後登録する(1パターン)

### DIFF
--- a/app/assets/javascripts/for_matching_datas.coffee
+++ b/app/assets/javascripts/for_matching_datas.coffee
@@ -1,0 +1,6 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/
+$ ->
+  $('#file').change ->
+    $('#file_name').val($(this).prop('files')[0].name)

--- a/app/controllers/for_matching_datas/csv_import_controller.rb
+++ b/app/controllers/for_matching_datas/csv_import_controller.rb
@@ -2,5 +2,10 @@ class ForMatchingDatas::CsvImportController < ApplicationController
   def import; end
 
   def import_csv
+    for_matching_datas = ForMatchingDataImportCsv.import(params[:file].tempfile)
+    for_matching_datas.each(&:save)
+    redirect_to for_matching_datas_import_path, notice: 'matching data imported.'
+  rescue
+    redirect_to for_matching_datas_import_path, alert: 'import failed.'
   end
 end

--- a/app/controllers/for_matching_datas/csv_import_controller.rb
+++ b/app/controllers/for_matching_datas/csv_import_controller.rb
@@ -1,0 +1,6 @@
+class ForMatchingDatas::CsvImportController < ApplicationController
+  def import; end
+
+  def import_csv
+  end
+end

--- a/app/controllers/for_matching_datas/csv_import_controller.rb
+++ b/app/controllers/for_matching_datas/csv_import_controller.rb
@@ -2,8 +2,7 @@ class ForMatchingDatas::CsvImportController < ApplicationController
   def import; end
 
   def import_csv
-    for_matching_datas = ForMatchingDataImportCsv.import(params[:file].tempfile)
-    for_matching_datas.each(&:save)
+    ForMatchingDataImportCsv.import(params[:file].tempfile)
     redirect_to for_matching_datas_import_path, notice: 'matching data imported.'
   rescue
     redirect_to for_matching_datas_import_path, alert: 'import failed.'

--- a/app/models/for_matching_data.rb
+++ b/app/models/for_matching_data.rb
@@ -1,6 +1,6 @@
 class ForMatchingData < ActiveRecord::Base
 
-  %i(format_type document_no model_code doc_type_str sht rev eo_chgno chg_type_str mcl scp_for_smpl scml revision).each do |attribute|
+  %i(format_type document_no model_code doc_no doc_type_str sht rev eo_chgno chg_type_str mcl scp_for_smpl scml revision).each do |attribute|
     validates attribute, length: { maximum: 255 }
   end
 

--- a/app/models/for_matching_data_import_csv.rb
+++ b/app/models/for_matching_data_import_csv.rb
@@ -20,29 +20,21 @@ class ForMatchingDataImportCsv
   class << self
     def import(file)
       @file = file
-      build_for_matching_datas
+      create_for_matching_datas
     end
 
     private
 
-    def build_for_matching_datas
-      for_matching_datas = []
-      for_matching_data_attributes_arr.each do |attributes|
-        for_matching_datas << ForMatchingData.new(attributes)
-      end
-      for_matching_datas
-    end
-
-    def for_matching_data_attributes_arr
-      attributes_arr = []
-      CSV.foreach(@file, encoding: 'SJIS:UTF-8', col_sep: "\t") do |row|
-        attributes = {}
-        CSV_COLMUN.each do |key, idx|
-          attributes.store(key, row[idx])
+    def create_for_matching_datas
+      ForMatchingData.transaction do
+        CSV.foreach(@file, encoding: 'SJIS:UTF-8', col_sep: "\t") do |row|
+          attributes = {}
+          CSV_COLMUN.each do |key, idx|
+            attributes.store(key, row[idx])
+          end
+          ForMatchingData.create(attributes)
         end
-        attributes_arr << attributes
       end
-      attributes_arr
     end
   end
 end

--- a/app/models/for_matching_data_import_csv.rb
+++ b/app/models/for_matching_data_import_csv.rb
@@ -1,0 +1,48 @@
+require 'csv'
+
+class ForMatchingDataImportCsv
+  CSV_COLMUN = {
+    format_type:  0,
+    document_no:  1,
+    model_code:   2,
+    doc_no:       3,
+    doc_type_str: 4,
+    sht:          5,
+    rev:          6,
+    eo_chgno:     7,
+    chg_type_str: 8,
+    mcl:          9,
+    scp_for_smpl: 10,
+    scml:         11,
+    revision:     12
+  }.freeze
+
+  class << self
+    def import(file)
+      @file = file
+      build_for_matching_datas
+    end
+
+    private
+
+    def build_for_matching_datas
+      for_matching_datas = []
+      for_matching_data_attributes_arr.each do |attributes|
+        for_matching_datas << ForMatchingData.new(attributes)
+      end
+      for_matching_datas
+    end
+
+    def for_matching_data_attributes_arr
+      attributes_arr = []
+      CSV.foreach(@file, encoding: 'SJIS:UTF-8', col_sep: "\t") do |row|
+        attributes = {}
+        CSV_COLMUN.each do |key, idx|
+          attributes.store(key, row[idx])
+        end
+        attributes_arr << attributes
+      end
+      attributes_arr
+    end
+  end
+end

--- a/app/views/for_matching_datas/csv_import/import.html.erb
+++ b/app/views/for_matching_datas/csv_import/import.html.erb
@@ -1,0 +1,32 @@
+<h1><%= t('.title') %></h1>
+
+<div class="row">
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= t('.csv_import') %></h3>
+  </div>
+  <div class="panel-body">
+
+<div class="row">
+  <%= form_tag for_matching_datas_import_path, method: :post, multipart: true do %>
+    <div class="row">
+      <div class="col-lg-1">
+        <%= label_tag :file, t('.choose'), class: 'btn btn-default', style: 'margin-left: 10px;' %>
+      </div>
+      <div class="col-lg-4">
+        <%= text_field_tag :file_name, nil, class: 'form-control', readonly: true %>
+        <%= file_field_tag :file, style: 'display: none' %>
+      </div>
+      <div class="col-lg-7">
+        <%= submit_tag t('.registration'), class: 'btn btn-primary'  %>
+      </div>
+    </div>
+  <% end %>
+</div>
+</div>
+</div>
+</div>
+<div class="row" style="margin-top: 15px;" >
+  <%= link_to 'Back', request_applications_path %>
+</div>
+<%= javascript_include_tag 'for_matching_datas' %>

--- a/app/views/for_matching_datas/csv_import/import.html.erb
+++ b/app/views/for_matching_datas/csv_import/import.html.erb
@@ -1,30 +1,34 @@
 <h1><%= t('.title') %></h1>
-
+<% if notice.present? %>
+  <p id="notice"><%= notice %></p>
+<% end %>
+<% if alert.present? %>
+  <p class="alert-danger"><%= alert %></p>
+<% end %>
 <div class="row">
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title"><%= t('.csv_import') %></h3>
-  </div>
-  <div class="panel-body">
-
-<div class="row">
-  <%= form_tag for_matching_datas_import_path, method: :post, multipart: true do %>
-    <div class="row">
-      <div class="col-lg-1">
-        <%= label_tag :file, t('.choose'), class: 'btn btn-default', style: 'margin-left: 10px;' %>
-      </div>
-      <div class="col-lg-4">
-        <%= text_field_tag :file_name, nil, class: 'form-control', readonly: true %>
-        <%= file_field_tag :file, style: 'display: none' %>
-      </div>
-      <div class="col-lg-7">
-        <%= submit_tag t('.registration'), class: 'btn btn-primary'  %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= t('.csv_import') %></h3>
+    </div>
+    <div class="panel-body">
+      <div class="row">
+        <%= form_tag for_matching_datas_import_path, method: :post, multipart: true do %>
+          <div class="row">
+            <div class="col-lg-1">
+              <%= label_tag :file, t('.choose'), class: 'btn btn-default', style: 'margin-left: 10px;' %>
+            </div>
+            <div class="col-lg-4">
+              <%= text_field_tag :file_name, nil, class: 'form-control', readonly: true %>
+              <%= file_field_tag :file, style: 'display: none' %>
+            </div>
+            <div class="col-lg-7">
+              <%= submit_tag t('.registration'), class: 'btn btn-primary'  %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
-  <% end %>
-</div>
-</div>
-</div>
+  </div>
 </div>
 <div class="row" style="margin-top: 15px;" >
   <%= link_to 'Back', request_applications_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,14 +10,13 @@
 <body>
 
 <div class="container">
-
-  <span> <%= link_to '進捗状況', request_applications_path %></span>　｜　
-  <span> <%= link_to '部署/プロジェクト', depts_path %></span>　
-  <span> <%= link_to '機種', models_path %></span>　
-  <span> <%= link_to '担当課', sections_path %></span>　｜　
-  <span> <%= link_to 'フロー順登録', flow_orders_path %></span>　｜　
-  <span> <%= link_to t('.request_applications_export_csv'), search_request_applications_path %></span>　｜　
-  <span> <%= link_to t('.for_matching_datas_import_csv'), for_matching_datas_import_path %></span>　｜　
+  <span><%= link_to '進捗状況', request_applications_path %></span>　｜　
+  <span><%= link_to '部署/プロジェクト', depts_path %></span>　
+  <span><%= link_to '機種', models_path %></span>　
+  <span><%= link_to '担当課', sections_path %></span>　｜　
+  <span><%= link_to 'フロー順登録', flow_orders_path %></span>　｜　
+  <span><%= link_to t('.request_applications_export_csv'), search_request_applications_path %></span>　｜　
+  <span><%= link_to t('.for_matching_datas_import_csv'), for_matching_datas_import_path %></span>
   <hr>
   <%= yield %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,8 @@
   <span> <%= link_to '機種', models_path %></span>　
   <span> <%= link_to '担当課', sections_path %></span>　｜　
   <span> <%= link_to 'フロー順登録', flow_orders_path %></span>　｜　
-  <span> <%= link_to t('.request_applications_export_csv'), search_request_applications_path %></span>
+  <span> <%= link_to t('.request_applications_export_csv'), search_request_applications_path %></span>　｜　
+  <span> <%= link_to t('.for_matching_datas_import_csv'), for_matching_datas_import_path %></span>　｜　
   <hr>
   <%= yield %>
 </div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( *.js )

--- a/config/locales/views/for_matching_datas/csv_import/ja.yml
+++ b/config/locales/views/for_matching_datas/csv_import/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  for_matching_datas:
+    csv_import:
+      import:
+        title: 突合せ用データ一覧
+        choose: 参照
+        registration: 登録
+        csv_import: CSV取込

--- a/config/locales/views/layouts/ja.yml
+++ b/config/locales/views/layouts/ja.yml
@@ -2,3 +2,4 @@ ja:
   layouts:
     application:
       request_applications_export_csv: 突合せデータ取得用CSV出力
+      for_matching_datas_import_csv: 突合せ用データ一覧

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,11 @@ Rails.application.routes.draw do
   resources :depts
   resources :users
 
+  namespace :for_matching_datas do
+    get :import, to: 'csv_import#import'
+    post :import, to: 'csv_import#import_csv'
+  end
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20161219123807_add_doc_no_to_for_matching_data.rb
+++ b/db/migrate/20161219123807_add_doc_no_to_for_matching_data.rb
@@ -1,0 +1,5 @@
+class AddDocNoToForMatchingData < ActiveRecord::Migration
+  def change
+    add_column :for_matching_data, :doc_no, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,23 +75,6 @@ ActiveRecord::Schema.define(version: 20161219123807) do
     t.string   "doc_no"
   end
 
-  create_table "kpeace_output_for_matchings", force: :cascade do |t|
-    t.integer  "format_type"
-    t.string   "document_no"
-    t.string   "model_code"
-    t.string   "doc_type_str"
-    t.string   "sht"
-    t.string   "rev"
-    t.string   "eo_chgno"
-    t.string   "chg_type_str"
-    t.string   "mcl"
-    t.string   "scp_for_smpl"
-    t.string   "scml"
-    t.string   "revision"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-  end
-
   create_table "models", force: :cascade do |t|
     t.string   "code"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161216045532) do
+ActiveRecord::Schema.define(version: 20161219123807) do
 
   create_table "chg_types", force: :cascade do |t|
     t.string   "name"
@@ -59,6 +59,24 @@ ActiveRecord::Schema.define(version: 20161216045532) do
 
   create_table "for_matching_data", force: :cascade do |t|
     t.string   "format_type"
+    t.string   "document_no"
+    t.string   "model_code"
+    t.string   "doc_type_str"
+    t.string   "sht"
+    t.string   "rev"
+    t.string   "eo_chgno"
+    t.string   "chg_type_str"
+    t.string   "mcl"
+    t.string   "scp_for_smpl"
+    t.string   "scml"
+    t.string   "revision"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.string   "doc_no"
+  end
+
+  create_table "kpeace_output_for_matchings", force: :cascade do |t|
+    t.integer  "format_type"
     t.string   "document_no"
     t.string   "model_code"
     t.string   "doc_type_str"

--- a/spec/factories/for_matching_data.rb
+++ b/spec/factories/for_matching_data.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     format_type 'PICTURE'
     document_no 'KP／PICTURE／AAA／R01／N99／BVSR／(D)／ｲ-6#2／A-N／A'
     model_code 'KP'
+    doc_no 'AA10'
     doc_type_str 'PICTURE'
     sht 'AAA'
     rev 'R01'

--- a/spec/models/for_matching_data.rb
+++ b/spec/models/for_matching_data.rb
@@ -5,6 +5,7 @@ RSpec.describe ForMatchingData, type: :model do
     it { is_expected.to respond_to(:format_type) }
     it { is_expected.to respond_to(:document_no) }
     it { is_expected.to respond_to(:model_code) }
+    it { is_expected.to respond_to(:doc_no) }
     it { is_expected.to respond_to(:doc_type_str) }
     it { is_expected.to respond_to(:sht) }
     it { is_expected.to respond_to(:rev) }
@@ -21,7 +22,7 @@ RSpec.describe ForMatchingData, type: :model do
     let(:for_matching_data) { create(:for_matching_data) }
     it { is_expected.to be_valid }
 
-    %i(format_type document_no model_code doc_type_str sht rev eo_chgno chg_type_str mcl scp_for_smpl scml revision).each do |attribute|
+    %i(format_type document_no model_code doc_no doc_type_str sht rev eo_chgno chg_type_str mcl scp_for_smpl scml revision).each do |attribute|
       describe "#{attribute} max length validate" do
         context '256文字以上の場合' do
           it do
@@ -35,7 +36,7 @@ RSpec.describe ForMatchingData, type: :model do
     describe '複合ユニーク制約(document_no, revision)' do
       context '同一の値が既に存在した場合' do
         it do
-          attributes = { document_no: 'KP／PICTURE／AAA／R01／N99／BVSR／(D)／ｲ-6#2／A-N／A', revision: 'A' }
+          attributes = { document_no: 'KP／AA10／PICTURE／AAA／R01／N99／BVSR／(D)／ｲ-6#2／A-N／A', revision: 'A' }
           expect(create(:for_matching_data, attributes)).to be_valid
           expect(build(:for_matching_data, attributes)).to be_invalid
         end


### PR DESCRIPTION
作っていて思ったんですがタブ区切りの順番は変わらないはずなので、file_type毎に登録を変える必要ないなーと思いました。

```
作ってて気になったところ
・format_type毎に登録処理変える必要があると思っていたがタブ区切りの順番は変わらないはずなので不要…？
・for_matching_data側のvalidateでdocument_noとrevisionの複合ユニーク制約を入れているせいで毎回SQLが流れてちょっと遅い。
・仕方ないですが画面名が「突き合わせ用データ一覧」だけれど一覧がない。
・登録されている一覧を出すと件数が半端じゃない事になるので検索機能とページネーション(kaminari)入れたほうが良さそう。
・読込された件数と登録された件数知りたいかも？
```
大体こんなところが気になりました。
![fireshot capture 61 - denshowquick - http___localhost_3000_for_matching_datas_import](https://cloud.githubusercontent.com/assets/21189471/21314243/4de8b5ae-c639-11e6-8531-185a9d00c495.png)
