### PR TITLE
doc_type_idがブランクだった場合のエラー表示部分を修正

### DIFF
--- a/app/views/request_applications/import_excel.html.erb
+++ b/app/views/request_applications/import_excel.html.erb
@@ -89,7 +89,7 @@
                 <td class="<%= append_error_class(detail, :doc_no) %>">
                   <%= detail.doc_no %>
                 </td>
-                <td class="<%= append_error_class(detail, :doc_type) %>">
+                <td class="<%= append_error_class(detail, :doc_type_id) %>">
                   <%= detail.doc_type&.name %>
                 </td>
                 <td class="<%= append_error_class(detail, :sht) %>">
@@ -101,7 +101,7 @@
                 <td class="<%= append_error_class(detail, :eo_chgno) %>">
                   <%= detail.eo_chgno %>
                 </td>
-                <td class="<%= append_error_class(detail, :chg_type) %>">
+                <td class="<%= append_error_class(detail, :chg_type_id) %>">
                   <%= detail.chg_type&.name %>
                 </td>
                 <td class="<%= append_error_class(detail, :mcl) %>">

--- a/config/locales/models/request_application/ja.yml
+++ b/config/locales/models/request_application/ja.yml
@@ -18,3 +18,5 @@ ja:
         scp_for_smpl: SCP FOR SMPL
         scml_ln: SCML L/N
         vendor_code: V/C
+        doc_type_id: DOC TYPE
+        chg_type_id: CHGTYPE


### PR DESCRIPTION
errorsのkeyが `doc_type_id` でくるのでHTMLのclassが当たっていなかったのを修正
![doc_type](https://cloud.githubusercontent.com/assets/21189471/21375022/1bb82f16-c76e-11e6-8958-bebfbf4b9d62.png)
