### PR TITLE
[sp2-re2] #TK-01120 項番3

### DIFF
--- a/app/controllers/for_matching_datas/csv_import_controller.rb
+++ b/app/controllers/for_matching_datas/csv_import_controller.rb
@@ -1,7 +1,7 @@
 class ForMatchingDatas::CsvImportController < ApplicationController
   def import
-    # TODO: 絞込機能追加時に全件取得外す
-    @for_matching_datas = ForMatchingData.all
+    @q = ForMatchingData.ransack(params[:q])
+    @for_matching_datas = params[:q].present? ? @q.result.order(document_no: :ASC) : []
   end
 
   def import_csv

--- a/app/views/for_matching_datas/csv_import/import.html.erb
+++ b/app/views/for_matching_datas/csv_import/import.html.erb
@@ -42,9 +42,9 @@
         </div>
         <div class="col-lg-2">
           <div>
-            <%= f.label :document_no %>
+            <%= f.label :doc_no %>
           </div>
-          <%= f.search_field :document_no_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
+          <%= f.search_field :doc_no_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
         </div>
         <div class="col-lg-8">
           <br>

--- a/app/views/for_matching_datas/csv_import/import.html.erb
+++ b/app/views/for_matching_datas/csv_import/import.html.erb
@@ -30,7 +30,31 @@
     </div>
   </div>
 </div>
-<div class="row" style="margin-top: 15px;" >
+<div class="row">
+  <div class="well well-sm well-search">
+    <%= search_form_for @q, url: for_matching_datas_import_path, class: "form-inline", method: :get do |f| %>
+      <div class="row">
+        <div class="col-lg-2">
+          <div>
+            <%= f.label :document_no %>
+          </div>
+          <%= f.search_field :document_no_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
+        </div>
+        <div class="col-lg-2">
+          <div>
+            <%= f.label :model_code %>
+          </div>
+          <%= f.search_field :model_code_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
+        </div>
+        <div class="col-lg-8">
+          <br>
+          <%= f.submit t('.search'), class: 'btn btn-primary' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+<div class="row">
   <%= link_to 'Back', request_applications_path %>
 </div>
 <div class="row" style="margin-top: 15px;">

--- a/app/views/for_matching_datas/csv_import/import.html.erb
+++ b/app/views/for_matching_datas/csv_import/import.html.erb
@@ -35,19 +35,20 @@
     <%= search_form_for @q, url: for_matching_datas_import_path, class: "form-inline", method: :get do |f| %>
       <div class="row">
         <div class="col-lg-2">
-          <div>
-            <%= f.label :model_code %>
-          </div>
+          <%= f.label :model_code %>
+        </div>
+        <div class="col-lg-10">
+          <%= f.label :doc_no %>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-lg-2">
           <%= f.search_field :model_code_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
         </div>
         <div class="col-lg-2">
-          <div>
-            <%= f.label :doc_no %>
-          </div>
           <%= f.search_field :doc_no_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
         </div>
         <div class="col-lg-8">
-          <br>
           <%= f.submit t('.search'), class: 'btn btn-primary' %>
         </div>
       </div>

--- a/app/views/for_matching_datas/csv_import/import.html.erb
+++ b/app/views/for_matching_datas/csv_import/import.html.erb
@@ -36,15 +36,15 @@
       <div class="row">
         <div class="col-lg-2">
           <div>
-            <%= f.label :document_no %>
-          </div>
-          <%= f.search_field :document_no_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
-        </div>
-        <div class="col-lg-2">
-          <div>
             <%= f.label :model_code %>
           </div>
           <%= f.search_field :model_code_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
+        </div>
+        <div class="col-lg-2">
+          <div>
+            <%= f.label :document_no %>
+          </div>
+          <%= f.search_field :document_no_cont, class: "form-control input-sm", placeholder:  t('placeholder.partial_match') %>
         </div>
         <div class="col-lg-8">
           <br>

--- a/config/locales/views/for_matching_datas/csv_import/ja.yml
+++ b/config/locales/views/for_matching_datas/csv_import/ja.yml
@@ -6,3 +6,4 @@ ja:
         choose: 参照
         registration: 登録
         csv_import: CSV取込
+        search: 検索


### PR DESCRIPTION
項番4のドキュメント番号でソートして表示も一緒にやってます。

`Back` と表の間に検索欄置くと伝えていましたが使い勝手悪そうなので `Back` を検索の下に置いてます。

表に機種コードが表示されないけれどフォームとしては存在するので、
不必要であれば削るor表に機種コード追加します。

![3-4](https://cloud.githubusercontent.com/assets/21189471/21924694/8cae5f54-d9bd-11e6-947b-63ec5b7542ab.png)
