### PR TITLE
[sp3-ex2] #TK-01134 リコンサイル処理：不一致のデータを直しても一致にならない

### DIFF
--- a/app/models/request_application/matcher.rb
+++ b/app/models/request_application/matcher.rb
@@ -38,7 +38,7 @@ module RequestApplication::Matcher
       mcl: detail.mcl,
       scp_for_smpl: detail.scp_for_smpl,
       scml_ln: detail.scml_ln
-    }
+    }.delete_if { |_key, value| value.blank? }
   end
 
   def convert_for_matching_data_attribute_names(for_matching_data)
@@ -52,6 +52,6 @@ module RequestApplication::Matcher
       mcl: for_matching_data.mcl,
       scp_for_smpl: for_matching_data.scp_for_smpl,
       scml_ln: for_matching_data.scml
-    }
+    }.delete_if { |_key, value| value.blank? }
   end
 end

--- a/app/models/request_application/matcher.rb
+++ b/app/models/request_application/matcher.rb
@@ -38,7 +38,7 @@ module RequestApplication::Matcher
       mcl: detail.mcl,
       scp_for_smpl: detail.scp_for_smpl,
       scml_ln: detail.scml_ln
-    }.delete_if { |_key, value| value.blank? }
+    }.map { |key, value| [key, value.to_s] }.to_h
   end
 
   def convert_for_matching_data_attribute_names(for_matching_data)
@@ -52,6 +52,6 @@ module RequestApplication::Matcher
       mcl: for_matching_data.mcl,
       scp_for_smpl: for_matching_data.scp_for_smpl,
       scml_ln: for_matching_data.scml
-    }.delete_if { |_key, value| value.blank? }
+    }.map { |key, value| [key, value.to_s] }.to_h
   end
 end


### PR DESCRIPTION
`request_detail` と `for_matchin_data` の比較対象の値に `nil` や `空文字 `が入っている下記のような時に意図した動きにならないので修正。
```
a = { name: nil }
b = { name: '' }
```
この場合は `一致` として扱いたいが、 `a == b` で比較している関係上 `不一致` になるので、
```
delete_if { | _, value | value.blank? }
```
とすることで事前に対象から削除しておく。
