### PR TITLE
[sp3-ex2] #TK-01135 編集や削除のリンク名を訂正

### DIFF
--- a/app/views/for_matching_datas/model_code/index.html.erb
+++ b/app/views/for_matching_datas/model_code/index.html.erb
@@ -40,7 +40,7 @@
       <% @model_codes.each do |model_code| %>
         <tr>
           <td><%= model_code %></td>
-          <td class="text-center"><%= link_to t('.destroy'), for_matching_datas_model_code_path(model_code: model_code), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %></td>
+          <td class="text-center"><%= link_to t('template.destroy'), for_matching_datas_model_code_path(model_code: model_code), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/shared/_application_details_table.html.erb
+++ b/app/views/shared/_application_details_table.html.erb
@@ -30,8 +30,8 @@
             <td><%= detail.scp_for_smpl %></td>
             <td><%= detail.scml_ln %></td>
             <td><%= detail.vendor_code %></td>
-            <td><%= link_to t('.edit_request_detail'), edit_request_application_request_detail_path(request_application, detail) %></td>
-            <td><%= link_to t('.destroy_request_detail'), request_application_request_detail_path(request_application, detail), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td><%= link_to t('template.edit'), edit_request_application_request_detail_path(request_application, detail) %></td>
+            <td><%= link_to t('template.destroy'), request_application_request_detail_path(request_application, detail), method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/config/locales/views/for_matching_datas/model_code/ja.yml
+++ b/config/locales/views/for_matching_datas/model_code/ja.yml
@@ -4,5 +4,4 @@ ja:
       index:
         title: K-PEACEデータ削除
         search: 検索
-        destroy: 詳細行の[削除]
         back: 技術資料要求書一覧画面へ

--- a/config/locales/views/shared/ja.yml
+++ b/config/locales/views/shared/ja.yml
@@ -1,5 +1,0 @@
-ja:
-  shared:
-    application_details_table:
-      edit_request_detail: 詳細行の[編集]
-      destroy_request_detail: 詳細行の[削除]


### PR DESCRIPTION
`詳細行を[削除] ` 等になっている部分を  `削除` に変更。