### PR TITLE
[sp3-ex2] #TK-01136 機種(Model)の検索付プルダウンが普通のになってる時がある

### DIFF
--- a/app/assets/javascripts/request_applications.coffee
+++ b/app/assets/javascripts/request_applications.coffee
@@ -1,7 +1,7 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
-$ ->
+$(document).on 'turbolinks:load', ->
   $(".select-model").select2({
     theme: "bootstrap"
   })

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>DenshowQuick</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload' %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track' => 'reload' %>
   <%= csrf_meta_tags %>
   <meta name="robots" content="noindex">
 </head>


### PR DESCRIPTION
下記現象を修正
```
Ａ画面に、Ａ画面以外から遷移してきた場合（たとえば、上部リンクの「進捗状況」リンクの押下など)、プルダウンが普通のプルダウンになっている。
F5リロードすると治る…というか、検索付のプルダウンになる。
```