### PR TITLE
[sp4-ex1] #TK-01137 M画面の画面名が間違っている

### DIFF
--- a/config/locales/models/for_matching_data/ja.yml
+++ b/config/locales/models/for_matching_data/ja.yml
@@ -10,7 +10,7 @@ ja:
         doc_no: 技術資料番号
         doc_type_str: DOC TYPE
         sht: SHT
-        rev: 親REV
+        rev: 新REV
         eo_chgno: EO/CHG NO
         chg_type_str: CHG TYPE
         mcl: MCL

--- a/config/locales/models/for_matching_data/ja.yml
+++ b/config/locales/models/for_matching_data/ja.yml
@@ -10,7 +10,7 @@ ja:
         doc_no: 技術資料番号
         doc_type_str: DOC TYPE
         sht: SHT
-        rev: 新REV
+        rev: 親REV
         eo_chgno: EO/CHG NO
         chg_type_str: CHG TYPE
         mcl: MCL

--- a/config/locales/views/for_matching_datas/model_code/ja.yml
+++ b/config/locales/views/for_matching_datas/model_code/ja.yml
@@ -2,6 +2,6 @@ ja:
   for_matching_datas:
     model_code:
       index:
-        title: K-PEACEデータ削除
+        title: 登録済K-PEACE機種コード一覧
         search: 検索
         back: 技術資料要求書一覧画面へ

--- a/config/locales/views/layouts/ja.yml
+++ b/config/locales/views/layouts/ja.yml
@@ -3,5 +3,5 @@ ja:
     application:
       request_applications_export_csv: K-PEACEデータ取得用CSV出力
       for_matching_datas_import_csv: K-PEACEデータインポート
-      for_matching_datas_model_code: K-PEACEデータ削除
+      for_matching_datas_model_code: 登録済K-PEACE機種コード一覧
       request_application_matching: リコンサイル指示


### PR DESCRIPTION
M画面の画面名を `K-PEACEデータ削除` から `登録済K-PEACE機種コード一覧` へ修正。

あわせて資料上 `ForMatchingData` の `rev` が `親REV` と `新REV` の二通りになっていたので、
denshow-quick は `親REV` にしていたが、 `新REV` が正しかったのでそちらも修正。