### PR TITLE
[sp4-04] #TK-01146 エクセル取込時にprojectの値を設定しないように変更

### DIFF
--- a/app/models/request_application_import_excel.rb
+++ b/app/models/request_application_import_excel.rb
@@ -44,9 +44,7 @@ class RequestApplicationImportExcel
       convert_request_value_to_record_id!(attributes)
       convert_detail_value_to_record_id!(attributes[:details_attributes])
 
-      # TODO: 2015年仕様のrequest_applicationの関連を整理後に削除する
-      # request_applicationにexcelに存在しない値を詰める
-      attributes[:project_id] = Project.first.id || 1
+      # request_applicationに2015年仕様に関連したexcelに存在しない値を詰める
       attributes[:emargency] = false
       attributes[:close] = false
 


### PR DESCRIPTION
`request_application` の `project_id` を `null` で登録するように変更。
DB自体に `foreign_key` 等は設定されていなかったので他の部分は弄らず。
手入力側は https://github.com/ogis-Yamada-Shizuka/denshow-quick/pull/70 のPRで対応。