### PR TITLE
[sp4-01] #TK-01153 現在の技術資料要求書一覧を旧画面として退避

### DIFF
--- a/app/controllers/older_request_applications/request_applications_controller.rb
+++ b/app/controllers/older_request_applications/request_applications_controller.rb
@@ -1,6 +1,7 @@
 class OlderRequestApplications::RequestApplicationsController < ApplicationController
   # 過去のroot画面(request_applications/index)を保持しておくためのコントローラです。
   # 関連する Model 等が変更された場合の動作は保証せず。
+  # rubocop:disable all
 
   before_action :set_request_application, only: %i(
     show edit update destroy regist reject interrupt first_to_revert regist_memo reject_memo interrupt_memo first_to_revert_memo registration_result
@@ -118,7 +119,7 @@ class OlderRequestApplications::RequestApplicationsController < ApplicationContr
 
   def first_to_return_memo; end
 
-  # TODO: ファイル読込に失敗したのか、フォーマットが違うのかをexceptionで判定する
+  # ファイル読込に失敗したのか、フォーマットが違うのかをexceptionで判定するように作りかえる
   def import_excel
     @request_application = RequestApplicationImportExcel.import(params[:file].tempfile)
     @request_application.flows.build

--- a/app/controllers/older_request_applications/request_applications_controller.rb
+++ b/app/controllers/older_request_applications/request_applications_controller.rb
@@ -75,7 +75,7 @@ class OlderRequestApplications::RequestApplicationsController < ApplicationContr
     @request_application.flows.last.proceed
 
     respond_to do |format|
-      format.html { redirect_to request_applications_url, notice: 'Request application was successfully progress changed.' }
+      format.html { redirect_to older_request_applications_url, notice: 'Request application was successfully progress changed.' }
       format.json { head :no_content }
     end
   end
@@ -86,7 +86,7 @@ class OlderRequestApplications::RequestApplicationsController < ApplicationContr
     @request_application.flows.last.retreat
 
     respond_to do |format|
-      format.html { redirect_to request_applications_url, notice: 'Request application was successfully progress changed.' }
+      format.html { redirect_to older_request_applications_url, notice: 'Request application was successfully progress changed.' }
       format.json { head :no_content }
     end
   end
@@ -95,7 +95,7 @@ class OlderRequestApplications::RequestApplicationsController < ApplicationContr
     # 要求書の処理を中断終了する
     @request_application.interrupt
     respond_to do |format|
-      format.html { redirect_to request_applications_url, notice: 'Request application was successfully flow interrupted.' }
+      format.html { redirect_to older_request_applications_url, notice: 'Request application was successfully flow interrupted.' }
       format.json { head :no_content }
     end
   end
@@ -105,7 +105,7 @@ class OlderRequestApplications::RequestApplicationsController < ApplicationContr
     @request_application.flows.last.first_to_revert
 
     respond_to do |format|
-      format.html { redirect_to request_applications_url, notice: 'Request application was successfully progress changed.' }
+      format.html { redirect_to older_request_applications_url, notice: 'Request application was successfully progress changed.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/older_request_applications/request_applications_controller.rb
+++ b/app/controllers/older_request_applications/request_applications_controller.rb
@@ -1,7 +1,8 @@
+# rubocop:disable all
+
 class OlderRequestApplications::RequestApplicationsController < ApplicationController
   # 過去のroot画面(request_applications/index)を保持しておくためのコントローラです。
   # 関連する Model 等が変更された場合の動作は保証せず。
-  # rubocop:disable all
 
   before_action :set_request_application, only: %i(
     show edit update destroy regist reject interrupt first_to_revert regist_memo reject_memo interrupt_memo first_to_revert_memo registration_result

--- a/app/controllers/older_request_applications/request_applications_controller.rb
+++ b/app/controllers/older_request_applications/request_applications_controller.rb
@@ -1,0 +1,167 @@
+class OlderRequestApplications::RequestApplicationsController < ApplicationController
+  # 過去のroot画面(request_applications/index)を保持しておくためのコントローラです。
+  # 関連する Model 等が変更された場合の動作は保証せず。
+
+  before_action :set_request_application, only: %i(
+    show edit update destroy regist reject interrupt first_to_revert regist_memo reject_memo interrupt_memo first_to_revert_memo registration_result
+  )
+  before_action :set_memo, only: [:regist, :reject, :interrupt, :first_to_revert]
+
+  # GET /request_applications
+  # GET /request_applications.json
+  def index
+    #    @request_applications = RequestApplication.all.order(:created_at).reverse_order
+    @q = RequestApplication.ransack(params[:q])
+    @request_applications = @q.result.order(:created_at).reverse_order
+
+    @flow_orders = FlowOrder.order_list
+  end
+
+  # GET /request_applications/1
+  # GET /request_applications/1.json
+  def show; end
+
+  # GET /request_applications/new
+  def new
+    @request_application = RequestApplication.new
+  end
+
+  # GET /request_applications/1/edit
+  def edit; end
+
+  # POST /request_applications
+  # POST /request_applications.json
+  def create
+    @request_application = RequestApplication.new(request_application_params)
+    @request_application.flows.build
+    respond_to do |format|
+      if @request_application.save
+        format.html { change_redirect_to_by_commit_message }
+        format.json { render :show, status: :created, location: @request_application }
+      else
+        format.html { render :new }
+        format.json { render json: @request_application.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /request_applications/1
+  # PATCH/PUT /request_applications/1.json
+  def update
+    respond_to do |format|
+      if @request_application.update(request_application_params)
+        format.html { change_redirect_to_by_commit_message }
+        format.json { render :show, status: :ok, location: @request_application }
+      else
+        format.html { render :edit }
+        format.json { render json: @request_application.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /request_applications/1
+  # DELETE /request_applications/1.json
+  def destroy
+    @request_application.destroy
+    respond_to do |format|
+      format.html { redirect_to request_applications_url, notice: 'Request application was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  def regist
+    # 最新flowのprogressを生成する。（進捗を進める）
+    @request_application.flows.last.set_memo(@memo)
+    @request_application.flows.last.proceed
+
+    respond_to do |format|
+      format.html { redirect_to request_applications_url, notice: 'Request application was successfully progress changed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  def reject
+    # 最新flowのprogressを生成する。(進捗を戻す)
+    @request_application.flows.last.set_memo(@memo)
+    @request_application.flows.last.retreat
+
+    respond_to do |format|
+      format.html { redirect_to request_applications_url, notice: 'Request application was successfully progress changed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  def interrupt
+    # 要求書の処理を中断終了する
+    @request_application.interrupt
+    respond_to do |format|
+      format.html { redirect_to request_applications_url, notice: 'Request application was successfully flow interrupted.' }
+      format.json { head :no_content }
+    end
+  end
+
+  def first_to_revert
+    # フローの始めに戻す・。
+    @request_application.flows.last.first_to_revert
+
+    respond_to do |format|
+      format.html { redirect_to request_applications_url, notice: 'Request application was successfully progress changed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  def regist_memo; end
+
+  def reject_memo; end
+
+  def interrupt_memo; end
+
+  def first_to_return_memo; end
+
+  # TODO: ファイル読込に失敗したのか、フォーマットが違うのかをexceptionで判定する
+  def import_excel
+    @request_application = RequestApplicationImportExcel.import(params[:file].tempfile)
+    @request_application.flows.build
+    @request_application.save ? redirect_to(request_applications_path, notice: 'request imported.') : (render :import_excel)
+  rescue
+    redirect_to request_applications_path, notice: 'import failed.'
+  end
+
+  def registration_result; end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_request_application
+    @request_application = RequestApplication.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def request_application_params
+    params.require(:request_application).permit(
+      :management_no, :emargency, :filename, :request_date, :preferred_date, :close, :project_id, :memo, :model_id, :section_id,
+      flow_attributes: [:memo]
+    )
+  end
+
+  def set_memo
+    @memo = params[:flow][:memo].presence if params[:flow].present?
+    @request_application.flows.last.set_memo(@memo)
+  end
+
+  def change_redirect_to_by_commit_message
+    if params[:save_and_insert].present?
+      redirect_to new_request_application_request_detail_path(@request_application), notice: redirect_notice_message
+    else
+      redirect_to registration_result_request_application_path(@request_application), notice: redirect_notice_message
+    end
+  end
+
+  def redirect_notice_message
+    if action_name == 'create'
+      'Request application was successfully created.'
+    else
+      'Request application was successfully updated.'
+    end
+  end
+end

--- a/app/views/older_request_applications/request_applications/_history.html.erb
+++ b/app/views/older_request_applications/request_applications/_history.html.erb
@@ -1,0 +1,27 @@
+<h3>履歴</h3>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>History_no</th>
+      <th>Order</th>
+      <th>Dept</th>
+      <th>Start</th>
+      <th>End</th>
+      <th>memo</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @request_application.flows.each do |flow| %>
+      <tr>
+        <td><%= flow.history_no %></td>
+        <td><%= flow.order %></td>
+        <td><%= flow.dept.try(:name) %></td>
+         <td><%= flow.progress.try(:in_date) %></td>
+         <td><%= flow.progress.try(:out_date) %></td>
+        <td><%= simple_format(flow.memo) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/older_request_applications/request_applications/_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/_memo.html.erb
@@ -1,0 +1,17 @@
+<%= form_for(@request_application, url: url ) do |f| %>
+
+  <%= fields_for @request_application.flows.order(:history_no).last do |flow| %>
+  <div class="row">
+    <div class="col-sm-3">
+    <div class="field">
+      <%= flow.text_area :memo ,class: "form-control" %>
+    </div>
+    </div>
+  </div>
+  <% end %>
+
+    <div class="actions">
+      <%= f.submit class: "btn btn-primary" %>
+    </div>
+<% end %>
+

--- a/app/views/older_request_applications/request_applications/_search.html.erb
+++ b/app/views/older_request_applications/request_applications/_search.html.erb
@@ -1,0 +1,75 @@
+<div class="well">
+
+  <%= search_form_for(@q, url: older_request_applications_path, method: :get) do |f| %>
+
+    <div class="row">
+      <div class="col-sm-2">
+        <div class="form-group">
+          <%= f.label :dept_project %>
+          <%= f.collection_select :custom_scope, Dept.all, :id, :name, {include_blank: true }, class: "form-control input-sm"%>
+        </div>
+      </div>
+    </div>
+<hr>
+
+    <div class="row">
+      <div class="col-sm-2">
+        <div class="form-group">
+          <%= f.label :management_no %>
+          <%= f.text_field :management_no_cont, class: "form-control input-sm", placeholder: "部分一致" %>
+        </div>
+      </div>
+
+      <div class="col-sm-2">
+        <div class="form-group">
+          <%= f.label :model_id %>
+          <%= f.collection_select :model_id_eq, Model.order(code: :ASC), :id, :code, { include_blank: true }, class: "form-control input-sm select-model"  %>
+        </div>
+      </div>
+
+      <div class="col-sm-2">
+        <div class="form-group">
+          <%= f.label :section_id %>
+          <%= f.collection_select :section_id_eq, Section.all, :id, :name, {include_blank: true} , class: "form-control input-sm"%>
+        </div>
+      </div>
+
+      <div class="col-sm-2">
+        <div class="form-group">
+          <%= f.label :project_id %>
+          <%= f.collection_select :project_id_eq, Dept.projects, :id, :name, {include_blank: true }, class: "form-control input-sm"%>
+        </div>
+      </div>
+
+      <div class="col-sm-2">
+        <div class="form-group">
+          <%= f.label :close %>
+          <%= f.select :close_eq,[["済/中断",true],["未済", false]],  {prompt: ""}, class: "form-control input-sm"%>
+        </div>
+      </div>
+
+      <div class="col-sm-2">
+      </div>
+
+    </div>
+
+
+    <div class="row">
+      <div class="col-sm-12">
+        <%= f.label :preferred_date %>
+        <div class="form-inline">
+          <%= f.date_select :preferred_date_gteq, {include_blank: true, use_month_numbers: true, date_separator: ' ／ '}, class: "form-control input-sm"%>　～　
+          <%= f.date_select :preferred_date_lteq, {include_blank: true, use_month_numbers: true, date_separator: ' ／ '}, class: "form-control input-sm" %>
+        </div>
+      </div>
+    </div>
+    <br>
+    <div class="row">
+      <div class="col-sm-12">
+        <%= f.submit '検索', class: "btn btn-primary" %>
+        <%= link_to 'クリア', url_for, class: "btn btn-default" %>
+      </div>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/older_request_applications/request_applications/first_to_revert_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/first_to_revert_memo.html.erb
@@ -1,0 +1,5 @@
+<h1>最初に差し戻し 確認</h1>
+
+<%= render "memo", url: older_request_applications_revert_progress_path(@request_application) %>
+
+<%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/first_to_revert_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/first_to_revert_memo.html.erb
@@ -1,5 +1,5 @@
 <h1>最初に差し戻し 確認</h1>
 
-<%= render "memo", url: older_request_applications_revert_progress_path(@request_application) %>
+<%= render "memo", url: revert_progress_older_request_application_path(@request_application) %>
 
 <%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/index.html.erb
+++ b/app/views/older_request_applications/request_applications/index.html.erb
@@ -67,9 +67,9 @@
         <td rowspan="2">|</td>
         <% request_application.flows.latest_flows(Flow.latest_ids(request_application.id)).each do |flow| %>
         <td rowspan="2">
-          <%= ( flow.progress.try(:in_date) || (link_to 'Start', older_request_applications_regist_progress_path(request_application), class:"btn btn-warning btn-xs" unless request_application.close?
+          <%= ( flow.progress.try(:in_date) || (link_to 'Start', regist_progress_older_request_application_path(request_application), class:"btn btn-warning btn-xs" unless request_application.close?
  )) %><br>
-          <%= ( flow.progress.try(:out_date) || (link_to 'End', older_request_applications_regist_memo_path(request_application), class:"btn btn-warning btn-xs"  unless (flow.progress.try(:in_date).blank?  ||  request_application.close?  || current_order != flow.order) ) ) %>
+          <%= ( flow.progress.try(:out_date) || (link_to 'End', regist_memo_older_request_application_path(request_application), class:"btn btn-warning btn-xs"  unless (flow.progress.try(:in_date).blank?  ||  request_application.close?  || current_order != flow.order) ) ) %>
         </td>
          <% end %>
          <% (@flow_orders.count - request_application.flows.maximum(:order)).times do %>
@@ -80,9 +80,9 @@
         <%= (link_to t('template.edit'), '#') unless request_application.close? %>
         <%= (link_to t('template.destroy'), '#', data: { confirm: 'Are you sure?' })  if request_application.delete_permit? %>
       </td>
-        <td rowspan="2"><%= link_to t('.reject') , older_request_applications_reject_memo_path(request_application) if request_application.flows.order(:history_no).last.reject? %></td>
-        <td rowspan="2"><%= link_to t('.revert') , older_request_applications_revert_memo_path(request_application) if request_application.flows.order(:history_no).last.first_to_revert? %></td>
-        <td rowspan="2"><%= link_to t('.interrupt') , older_request_applications_interrupt_memo_path(request_application)  if request_application.interrupt_permit? %></td>
+        <td rowspan="2"><%= link_to t('.reject') , reject_memo_older_request_application_path(request_application) if request_application.flows.order(:history_no).last.reject? %></td>
+        <td rowspan="2"><%= link_to t('.revert') , revert_memo_older_request_application_path(request_application) if request_application.flows.order(:history_no).last.first_to_revert? %></td>
+        <td rowspan="2"><%= link_to t('.interrupt') , interrupt_memo_older_request_application_path(request_application)  if request_application.interrupt_permit? %></td>
 
       </tr>
       <tr>

--- a/app/views/older_request_applications/request_applications/index.html.erb
+++ b/app/views/older_request_applications/request_applications/index.html.erb
@@ -1,0 +1,97 @@
+<h1><%= t('.title') %></h1>
+<%= render 'search' %>
+
+<div class="row">
+  <div class="col-lg-2">
+    <%= link_to t('.new_request_application'), '#', class: 'btn btn-default' %>
+  </div>
+  <div class="col-lg-1">
+  </div>
+  <div class="col-lg-9">
+    <div class="row">
+    <%= form_tag '#', multipart: true do %>
+      <div class="col-lg-4">
+        <%= file_field_tag :file, accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' %>
+      </div>
+      <div class="col-lg-8">
+        <%= submit_tag t('.import_excel'), class: 'btn btn-primary', disabled: true  %>
+      </div>
+    <% end %>
+    </div>
+  </div>
+</div>
+
+<br>
+
+<table class="table  table-striped">
+  <thead>
+    <tr>
+
+      <th rowspan="2"><%= t('activerecord.attributes.request_application.management_no') %></th>
+      <th>Project</th>
+      <th>model</th>
+      <th>section</th>
+      <th>File</th>
+
+      <th rowspan="2">|</th>
+       <% @flow_orders.each do |flow_order| %>
+        <th rowspan="2">
+          <%= flow_order.dept.try(:name).presence || t('.project') %>
+        </th>
+       <% end %>
+      <th rowspan="2"></th>
+      <th rowspan="2"></th>
+      <th rowspan="2"></th>
+      <th rowspan="2"></th>
+
+    </tr>
+    <tr>
+      <th>E!</th>
+      <th><%= sort_link(@q, :close) %></th>
+      <th>Request date</th>
+      <th>Preferred date</th>
+
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @request_applications.each do |request_application| %>
+    <% current_order = request_application.current_order %>
+      <tr>
+        <td rowspan="2"><%= link_to request_application.management_no, registration_result_request_application_path(request_application) %></td>
+        <td><%= request_application.project.try(:name) %></td>
+        <td><%= request_application.model.try(:code) %></td>
+        <td><%= request_application.section.try(:name) %></td>
+        <td><%= (link_to "Download" , request_application.filename_url) if request_application.filename_url.present? %></td>
+
+        <td rowspan="2">|</td>
+        <% request_application.flows.latest_flows(Flow.latest_ids(request_application.id)).each do |flow| %>
+        <td rowspan="2">
+          <%= ( flow.progress.try(:in_date) || (link_to 'Start', older_request_applications_regist_progress_path(request_application), class:"btn btn-warning btn-xs" unless request_application.close?
+ )) %><br>
+          <%= ( flow.progress.try(:out_date) || (link_to 'End', older_request_applications_regist_memo_path(request_application), class:"btn btn-warning btn-xs"  unless (flow.progress.try(:in_date).blank?  ||  request_application.close?  || current_order != flow.order) ) ) %>
+        </td>
+         <% end %>
+         <% (@flow_orders.count - request_application.flows.maximum(:order)).times do %>
+          <td rowspan="2"></td>
+         <% end %>
+
+        <td rowspan="2"><%= link_to t('.show_request_application_status_detail'), older_request_application_path(request_application) %>
+        <%= (link_to t('template.edit'), '#') unless request_application.close? %>
+        <%= (link_to t('template.destroy'), '#', data: { confirm: 'Are you sure?' })  if request_application.delete_permit? %>
+      </td>
+        <td rowspan="2"><%= link_to t('.reject') , older_request_applications_reject_memo_path(request_application) if request_application.flows.order(:history_no).last.reject? %></td>
+        <td rowspan="2"><%= link_to t('.revert') , older_request_applications_revert_memo_path(request_application) if request_application.flows.order(:history_no).last.first_to_revert? %></td>
+        <td rowspan="2"><%= link_to t('.interrupt') , older_request_applications_interrupt_memo_path(request_application)  if request_application.interrupt_permit? %></td>
+
+      </tr>
+      <tr>
+        <td><%= t('.emargency') if request_application.emargency %></td>
+        <td><%= request_application.close_status %></td>
+        <td><%= request_application.request_date %></td>
+        <td><%= request_application.preferred_date %></td>
+
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/older_request_applications/request_applications/index.json.jbuilder
+++ b/app/views/older_request_applications/request_applications/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@request_applications) do |request_application|
+  json.extract! request_application, :id, :management_no, :emargency, :filename, :request_date, :preferred_date, :close
+  json.url request_application_url(request_application, format: :json)
+end

--- a/app/views/older_request_applications/request_applications/interrupt_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/interrupt_memo.html.erb
@@ -1,5 +1,5 @@
 <h1>中断　確認</h1>
 
-<%= render "memo", url: older_request_applications_interrupt_progress_path(@request_application) %>
+<%= render "memo", url: interrupt_progress_older_request_application_path(@request_application) %>
 
 <%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/interrupt_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/interrupt_memo.html.erb
@@ -1,0 +1,5 @@
+<h1>中断　確認</h1>
+
+<%= render "memo", url: older_request_applications_interrupt_progress_path(@request_application) %>
+
+<%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/regist_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/regist_memo.html.erb
@@ -1,0 +1,5 @@
+<h1>進捗 確認</h1>
+
+<%= render "memo", url: older_request_applications_regist_progress_path(@request_application) %>
+
+<%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/regist_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/regist_memo.html.erb
@@ -1,5 +1,5 @@
 <h1>進捗 確認</h1>
 
-<%= render "memo", url: older_request_applications_regist_progress_path(@request_application) %>
+<%= render "memo", url: regist_progress_older_request_application_path(@request_application) %>
 
 <%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/reject_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/reject_memo.html.erb
@@ -1,5 +1,5 @@
 <h1>差し戻し　確認</h1>
 
-<%= render "memo", url: older_request_applications_reject_progress_path(@request_application) %>
+<%= render "memo", url: reject_progress_older_request_application_path(@request_application) %>
 
 <%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/reject_memo.html.erb
+++ b/app/views/older_request_applications/request_applications/reject_memo.html.erb
@@ -1,0 +1,5 @@
+<h1>差し戻し　確認</h1>
+
+<%= render "memo", url: older_request_applications_reject_progress_path(@request_application) %>
+
+<%= link_to 'Cancel', older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/show.html.erb
+++ b/app/views/older_request_applications/request_applications/show.html.erb
@@ -1,0 +1,56 @@
+<p>
+  <strong><%= t('activerecord.attributes.request_application.management_no') %>:</strong>
+  <%= @request_application.management_no %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.emargency') %>:</strong>
+  <%= @request_application.emargency %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.filename') %>:</strong>
+  <%= @request_application.filename %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.request_date') %>:</strong>
+  <%= @request_application.request_date %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.preferred_date') %>:</strong>
+  <%= @request_application.preferred_date %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.close') %>:</strong>
+  <%= @request_application.close_status %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.memo') %>:</strong>
+  <%= simple_format(@request_application.memo) %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.model') %>:</strong>
+<%= @request_application.model.try(:code) %>
+
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.request_application.section') %>:</strong>
+  <%= @request_application.section.try(:name) %>
+</p>
+
+
+<hr>
+
+<%= render 'history'  %>
+
+
+<% unless @request_application.close? %>
+  <%= link_to t('.edit'), '#' %> |
+<% end %>
+<%= link_to t('.back'), older_request_applications_path %>

--- a/app/views/older_request_applications/request_applications/show.json.jbuilder
+++ b/app/views/older_request_applications/request_applications/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @request_application, :id, :management_no, :emargency, :filename, :request_date, :preferred_date, :close, :created_at, :updated_at

--- a/config/locales/views/older_request_applications/request_applications/ja.yml
+++ b/config/locales/views/older_request_applications/request_applications/ja.yml
@@ -1,0 +1,34 @@
+ja:
+  older_request_applications:
+    request_applications:
+      index:
+        title: 技術資料要求書一覧
+        new_request_application: 要求書新規受付
+        show_request_application_status_detail: 進捗状況詳細
+        import_excel: データインポート
+        search: 検索
+        csv_export: CSV出力
+        choose_output: 出力
+        project: プロジェクト
+        reject: 差戻
+        revert: 最初に差戻
+        interrupt: 中断
+        emargency: 緊急
+      new:
+        title: 要求書新規受付
+        save_and_insert: 詳細入力画面へ
+        back: 技術資料要求書一覧画面へ
+      show:
+        edit: 要求書情報編集画面へ
+        back: 技術資料要求書一覧画面へ
+      edit:
+        title: 要求書情報編集
+        update_request_applicaton: 編集した内容を保存
+        show: 進捗状況詳細画面へ
+        back: 技術資料要求書一覧画面へ
+        add_request_detail: 技術資料詳細を追加
+      registration_result:
+        title: 要求書＆技術資料詳細
+        edit_request_application: 要求書情報編集
+        add_request_detail: 技術資料詳細を追加
+        back: 技術資料要求書一覧画面へ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,11 @@ Rails.application.routes.draw do
     delete :model_code, to: 'model_code#destroy'
   end
 
+  namespace :older_request_applications do
+    get '/', to: 'request_applications#index'
+    get :search, to: 'request_applications#search'
+  end
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,26 +57,22 @@ Rails.application.routes.draw do
   end
 
   # 2015年版に関する request_application の index, show, 進捗状況更新等のルーティングを記載。
-  namespace :older_request_applications do
-    get '/', to: 'request_applications#index'
-    get 'request_applications/:id/regist_memo' => 'request_applications#regist_memo', as: :regist_memo
-    get 'request_applications/:id/regist' => 'request_applications#regist', as: :regist_progress
-    patch 'request_applications/:id/regist' => 'request_applications#regist', as: :regist_confirm
-
-    get 'request_applications/:id/reject_memo' => 'request_applications#reject_memo', as: :reject_memo
-    get 'request_applications/:id/reject' => 'request_applications#reject', as: :reject_progress
-    patch 'request_applications/:id/reject' => 'request_applications#reject', as: :reject_confirm
-
-    get 'request_applications/:id/interrupt_memo' => 'request_applications#interrupt_memo', as: :interrupt_memo
-    get 'request_applications/:id/interrupt' => 'request_applications#interrupt', as: :interrupt_progress
-    patch 'request_applications/:id/interrupt' => 'request_applications#interrupt', as: :interrupt_confirm
-
-    get 'request_applications/:id/revert_memo' => 'request_applications#first_to_revert_memo', as: :revert_memo
-    get 'request_applications/:id/revert' => 'request_applications#first_to_revert', as: :revert_progress
-    patch 'request_applications/:id/revert' => 'request_applications#first_to_revert', as: :revert_confirm
+  resources :older_request_applications, controller: 'older_request_applications/request_applications', only: %i(index show) do
+    member do
+      get :regist_memo, as: :regist_memo
+      get :regist, as: :regist_progress
+      patch :regist, as: :regist_confirm
+      get :reject_memo
+      get :reject, as: :reject_progress
+      patch :reject, as: :reject_confirm
+      get :interrupt_memo
+      get :interrupt, as: :interrupt_progress
+      patch :interrupt, as: :interrupt_confirm
+      get :first_to_revert_memo, as: :revert_memo
+      get :first_to_revert, as: :revert_progress
+      patch :first_to_revert, as: :revert_confirm
+    end
   end
-  get 'older_request_applications/:id/' => 'older_request_applications/request_applications#show', as: :older_request_application
-
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,10 +56,27 @@ Rails.application.routes.draw do
     delete :model_code, to: 'model_code#destroy'
   end
 
+  # 2015年版に関する request_application の index, show, 進捗状況更新等のルーティングを記載。
   namespace :older_request_applications do
     get '/', to: 'request_applications#index'
-    get :search, to: 'request_applications#search'
+    get 'request_applications/:id/regist_memo' => 'request_applications#regist_memo', as: :regist_memo
+    get 'request_applications/:id/regist' => 'request_applications#regist', as: :regist_progress
+    patch 'request_applications/:id/regist' => 'request_applications#regist', as: :regist_confirm
+
+    get 'request_applications/:id/reject_memo' => 'request_applications#reject_memo', as: :reject_memo
+    get 'request_applications/:id/reject' => 'request_applications#reject', as: :reject_progress
+    patch 'request_applications/:id/reject' => 'request_applications#reject', as: :reject_confirm
+
+    get 'request_applications/:id/interrupt_memo' => 'request_applications#interrupt_memo', as: :interrupt_memo
+    get 'request_applications/:id/interrupt' => 'request_applications#interrupt', as: :interrupt_progress
+    patch 'request_applications/:id/interrupt' => 'request_applications#interrupt', as: :interrupt_confirm
+
+    get 'request_applications/:id/revert_memo' => 'request_applications#first_to_revert_memo', as: :revert_memo
+    get 'request_applications/:id/revert' => 'request_applications#first_to_revert', as: :revert_progress
+    patch 'request_applications/:id/revert' => 'request_applications#first_to_revert', as: :revert_confirm
   end
+  get 'older_request_applications/:id/' => 'older_request_applications/request_applications#show', as: :older_request_application
+
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/controller/older_request_applications_spec.rb
+++ b/spec/controller/older_request_applications_spec.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe OlderRequestApplications::RequestApplicationsController, type: :controller do
-
-  describe 'OlderRequestApplicationsController test' do
-    describe 'GET #index' do
-      before { get :index }
-      it { expect(response.status).to eq(200) }
-    end
+  describe 'GET #index' do
+    before { get :index }
+    it { expect(response.status).to eq(200) }
   end
 end

--- a/spec/controller/older_request_applications_spec.rb
+++ b/spec/controller/older_request_applications_spec.rb
@@ -3,22 +3,9 @@ require 'rails_helper'
 RSpec.describe OlderRequestApplications::RequestApplicationsController, type: :controller do
 
   describe 'OlderRequestApplicationsController test' do
-    let(:dept) { create(:dept) }
-    let(:flow_order) { create(:flow_order, dept: dept) }
-    let(:request_application) { create(:request_application) }
-    let(:flow) { create(:flow, dept: dept, request_application: request_application) }
-
-    let(:q) { RequestApplication.ransack(nil) }
-    let(:request_applications) { q.result.order(:created_at).reverse_order }
-    let(:flow_orders) { FlowOrder.order_list }
-
     describe 'GET #index' do
       before { get :index }
-      it { expect(assigns(:request_applications)).to eq request_applications }
-      it { expect(assigns(:flow_orders)).to eq flow_orders }
-
       it { expect(response.status).to eq(200) }
-      it { expect(response).to render_template(:index) }
     end
   end
 end

--- a/spec/controller/older_request_applications_spec.rb
+++ b/spec/controller/older_request_applications_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe OlderRequestApplications::RequestApplicationsController, type: :controller do
+
+  describe 'OlderRequestApplicationsController test' do
+    let(:dept) { create(:dept) }
+    let(:flow_order) { create(:flow_order, dept: dept) }
+    let(:request_application) { create(:request_application) }
+    let(:flow) { create(:flow, dept: dept, request_application: request_application) }
+
+    let(:q) { RequestApplication.ransack(nil) }
+    let(:request_applications) { q.result.order(:created_at).reverse_order }
+    let(:flow_orders) { FlowOrder.order_list }
+
+    describe 'GET #index' do
+      before { get :index }
+      it { expect(assigns(:request_applications)).to eq request_applications }
+      it { expect(assigns(:flow_orders)).to eq flow_orders }
+
+      it { expect(response.status).to eq(200) }
+      it { expect(response).to render_template(:index) }
+    end
+  end
+end


### PR DESCRIPTION
現在の画面を変更する前に、旧画面として退避させました。
対象は index, show, 進捗状況等の変更部分です。
退避させなかったその他の部分はリンクならリンク先を `#` に、
ボタンなら `disable` にしてます。