### PR TITLE
[sp4-01] #TK-01140 技術要求書一覧の画面内容を変更

### DIFF
--- a/app/assets/stylesheets/request_applications.scss
+++ b/app/assets/stylesheets/request_applications.scss
@@ -32,3 +32,11 @@ input.clicked {
 .reference-btn {
   margin-left: 10px;
 }
+
+.search-btn-row {
+  margin-top: 15px;
+}
+
+.between-label {
+  margin: 0px 6px;
+}

--- a/app/assets/stylesheets/request_applications.scss
+++ b/app/assets/stylesheets/request_applications.scss
@@ -16,3 +16,19 @@ input.check-all-button {
 input.clicked {
   background-color: #e6e6e6;
 }
+
+.panel-inner-row {
+  padding: 10px;
+}
+
+.new-request-panel {
+  padding: 15px 15px 0px;
+}
+
+.manual-input-btn {
+  margin-top: 12px;
+}
+
+.reference-btn {
+  margin-left: 10px;
+}

--- a/app/views/request_applications/_search.html.erb
+++ b/app/views/request_applications/_search.html.erb
@@ -1,45 +1,45 @@
 <div class="row">
-<div class="panel panel-default">
-  <div class="panel-heading"><%= t('.search_request_applicaton') %></div>
-  <div class="panel-body">
-    <%= search_form_for(@q, method: :get) do |f| %>
-      <div class="row">
-        <div class="col-sm-2">
-          <div class="form-group">
-            <%= f.label :management_no %>
-            <%= f.text_field :management_no_cont, class: 'form-control input-sm', placeholder: t('placeholder.partial_match') %>
+  <div class="panel panel-default">
+    <div class="panel-heading"><%= t('.search_request_applicaton') %></div>
+    <div class="panel-body">
+      <%= search_form_for(@q, method: :get) do |f| %>
+        <div class="row">
+          <div class="col-sm-2">
+            <div class="form-group">
+              <%= f.label :management_no %>
+              <%= f.text_field :management_no_cont, class: 'form-control input-sm', placeholder: t('placeholder.partial_match') %>
+            </div>
+          </div>
+          <div class="col-sm-2">
+            <div class="form-group">
+              <%= f.label :model, t('activerecord.attributes.request_application.model') %>
+              <%= f.collection_select :model_id_eq, Model.order(code: :ASC), :id, :code, { include_blank: true }, class: 'form-control input-sm select-model' %>
+            </div>
+          </div>
+          <div class="col-sm-2">
+            <div class="form-group">
+              <%= label :section, t('activerecord.attributes.request_application.section') %>
+              <%= f.collection_select :section_id_eq, Section.all, :id, :name, { include_blank: true } , class: 'form-control input-sm' %>
+            </div>
           </div>
         </div>
-        <div class="col-sm-2">
-          <div class="form-group">
-            <%= f.label :model, t('activerecord.attributes.request_application.model') %>
-            <%= f.collection_select :model_id_eq, Model.order(code: :ASC), :id, :code, { include_blank: true }, class: 'form-control input-sm select-model' %>
+        <div class="row">
+          <div class="col-sm-12">
+            <%= f.label :preferred_date %>
+            <div class="form-inline">
+              <%= f.text_field :preferred_date_gteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
+              <%= label :between_label, '～', class: 'between-label' %>
+              <%= f.text_field :preferred_date_lteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
+            </div>
           </div>
         </div>
-        <div class="col-sm-2">
-          <div class="form-group">
-            <%= label :section, t('activerecord.attributes.request_application.section') %>
-            <%= f.collection_select :section_id_eq, Section.all, :id, :name, { include_blank: true } , class: 'form-control input-sm' %>
+        <div class="row search-btn-row">
+          <div class="col-sm-12">
+            <%= f.submit t('template.search'), class: 'btn btn-primary' %>
+            <%= link_to t('template.clear'), url_for, class: 'btn btn-default' %>
           </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-12">
-          <%= f.label :preferred_date %>
-          <div class="form-inline">
-            <%= f.text_field :preferred_date_gteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
-            <%= label :between_label, '～', class: 'between-label' %>
-            <%= f.text_field :preferred_date_lteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
-          </div>
-        </div>
-      </div>
-      <div class="row search-btn-row">
-        <div class="col-sm-12">
-          <%= f.submit t('template.search'), class: 'btn btn-primary' %>
-          <%= link_to t('template.clear'), url_for, class: 'btn btn-default' %>
-        </div>
-      </div>
-    <% end %>
-  </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/request_applications/_search.html.erb
+++ b/app/views/request_applications/_search.html.erb
@@ -1,75 +1,45 @@
-<div class="well">
-
-  <%= search_form_for(@q, method: :get) do |f| %>
-
-    <div class="row">
-      <div class="col-sm-2">
-        <div class="form-group">
-          <%= f.label :dept_project %>
-          <%= f.collection_select :custom_scope, Dept.all, :id, :name, {include_blank: true }, class: "form-control input-sm"%>
+<div class="row">
+<div class="panel panel-default">
+  <div class="panel-heading"><%= t('.search_request_applicaton') %></div>
+  <div class="panel-body">
+    <%= search_form_for(@q, method: :get) do |f| %>
+      <div class="row">
+        <div class="col-sm-2">
+          <div class="form-group">
+            <%= f.label :management_no %>
+            <%= f.text_field :management_no_cont, class: 'form-control input-sm', placeholder: t('placeholder.partial_match') %>
+          </div>
+        </div>
+        <div class="col-sm-2">
+          <div class="form-group">
+            <%= f.label :model, t('activerecord.attributes.request_application.model') %>
+            <%= f.collection_select :model_id_eq, Model.order(code: :ASC), :id, :code, { include_blank: true }, class: 'form-control input-sm select-model' %>
+          </div>
+        </div>
+        <div class="col-sm-2">
+          <div class="form-group">
+            <%= label :section, t('activerecord.attributes.request_application.section') %>
+            <%= f.collection_select :section_id_eq, Section.all, :id, :name, { include_blank: true } , class: 'form-control input-sm' %>
+          </div>
         </div>
       </div>
-    </div>
-<hr>
-
-    <div class="row">
-      <div class="col-sm-2">
-        <div class="form-group">
-          <%= f.label :management_no %>
-          <%= f.text_field :management_no_cont, class: "form-control input-sm", placeholder: "部分一致" %>
+      <div class="row">
+        <div class="col-sm-12">
+          <%= f.label :preferred_date %>
+          <div class="form-inline">
+            <%= f.text_field :preferred_date_gteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
+            <%= label :between_label, '～', class: 'between-label' %>
+            <%= f.text_field :preferred_date_lteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
+          </div>
         </div>
       </div>
-
-      <div class="col-sm-2">
-        <div class="form-group">
-          <%= f.label :model_id %>
-          <%= f.collection_select :model_id_eq, Model.order(code: :ASC), :id, :code, { include_blank: true }, class: "form-control input-sm select-model"  %>
+      <div class="row search-btn-row">
+        <div class="col-sm-12">
+          <%= f.submit t('template.search'), class: 'btn btn-primary' %>
+          <%= link_to t('template.clear'), url_for, class: 'btn btn-default' %>
         </div>
       </div>
-
-      <div class="col-sm-2">
-        <div class="form-group">
-          <%= f.label :section_id %>
-          <%= f.collection_select :section_id_eq, Section.all, :id, :name, {include_blank: true} , class: "form-control input-sm"%>
-        </div>
-      </div>
-
-      <div class="col-sm-2">
-        <div class="form-group">
-          <%= f.label :project_id %>
-          <%= f.collection_select :project_id_eq, Dept.projects, :id, :name, {include_blank: true }, class: "form-control input-sm"%>
-        </div>
-      </div>
-
-      <div class="col-sm-2">
-        <div class="form-group">
-          <%= f.label :close %>
-          <%= f.select :close_eq,[["済/中断",true],["未済", false]],  {prompt: ""}, class: "form-control input-sm"%>
-        </div>
-      </div>
-
-      <div class="col-sm-2">
-      </div>
-
-    </div>
-
-
-    <div class="row">
-      <div class="col-sm-12">
-        <%= f.label :preferred_date %>
-        <div class="form-inline">
-          <%= f.text_field :preferred_date_gteq, placeholder: 'YYYY/MM/DD', class: 'form-control input-sm datetimepicker' %>　～　
-          <%= f.text_field :preferred_date_lteq, placeholder: 'YYYY/MM/DD', class: 'form-control input-sm datetimepicker' %>
-        </div>
-      </div>
-    </div>
-    <br>
-    <div class="row">
-      <div class="col-sm-12">
-        <%= f.submit '検索', class: "btn btn-primary" %>
-        <%= link_to 'クリア', url_for, class: "btn btn-default" %>
-      </div>
-    </div>
-  <% end %>
-
+    <% end %>
+  </div>
+  </div>
 </div>

--- a/app/views/request_applications/index.html.erb
+++ b/app/views/request_applications/index.html.erb
@@ -1,27 +1,35 @@
 <h1><%= t('.title') %></h1>
-<%= render 'search' %>
 
-<div class="row">
-  <div class="col-lg-2">
-    <%= link_to t('.new_request_application'), new_request_application_path, class: 'btn btn-default' %>
-  </div>
-  <div class="col-lg-1">
-  </div>
-  <div class="col-lg-9">
-    <div class="row">
-    <%= form_tag import_excel_request_applications_path, multipart: true do %>
-      <div class="col-lg-4">
-        <%= file_field_tag :file, accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' %>
+<div class="panel panel-default">
+  <div class="panel-heading"><%= t('.new_request_application') %></div>
+    <div class="panel-body new-request-panel">
+      <div class="row">
+        <div class="col-lg-2 text-center">
+          <%= link_to t('.manual_input'), new_request_application_path, class: 'btn btn-default manual-input-btn' %>
+        </div>
+        <div class="col-lg-10">
+          <div class="panel panel-default">
+            <div class="row panel-inner-row">
+              <%= form_tag import_excel_request_applications_path, multipart: true do %>
+                <div class="col-lg-2">
+                  <%= label_tag :file, t('.reference'), class: 'btn btn-default reference-btn' %>
+                </div>
+                <div class="col-lg-4">
+                  <%= text_field_tag :file_name, nil, class: 'form-control', readonly: true %>
+                  <%= file_field_tag :file, accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', style: 'display: none' %>
+                </div>
+                <div class="col-lg-6">
+                  <%= submit_tag t('.import_excel'), class: 'btn btn-primary'  %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="col-lg-8">
-        <%= submit_tag t('.import_excel'), class: 'btn btn-primary'  %>
-      </div>
-    <% end %>
     </div>
-  </div>
 </div>
 
-<br>
+<%= render 'search' %>
 
 <table class="table  table-striped">
   <thead>

--- a/app/views/request_applications/index.html.erb
+++ b/app/views/request_applications/index.html.erb
@@ -1,7 +1,9 @@
-<h1><%= t('.title') %></h1>
-
-<div class="panel panel-default">
-  <div class="panel-heading"><%= t('.new_request_application') %></div>
+<div class="row">
+  <h1><%= t('.title') %></h1>
+</div>
+<div class="row">
+  <div class="panel panel-default">
+    <div class="panel-heading"><%= t('.new_request_application') %></div>
     <div class="panel-body new-request-panel">
       <div class="row">
         <div class="col-lg-2 text-center">
@@ -27,11 +29,12 @@
         </div>
       </div>
     </div>
+  </div>
 </div>
 
 <%= render 'search' %>
 
-<table class="table  table-striped">
+<table class="table table-striped">
   <thead>
     <tr>
 

--- a/app/views/request_applications/index.html.erb
+++ b/app/views/request_applications/index.html.erb
@@ -34,75 +34,43 @@
 
 <%= render 'search' %>
 
-<table class="table table-striped">
-  <thead>
-    <tr>
-
-      <th rowspan="2"><%= t('activerecord.attributes.request_application.management_no') %></th>
-      <th>Project</th>
-      <th>model</th>
-      <th>section</th>
-      <th>File</th>
-
-      <th rowspan="2">|</th>
-       <% @flow_orders.each do |flow_order| %>
-        <th rowspan="2">
-          <%= flow_order.dept.try(:name).presence || t('.project') %>
-        </th>
-       <% end %>
-      <th rowspan="2"></th>
-      <th rowspan="2"></th>
-      <th rowspan="2"></th>
-      <th rowspan="2"></th>
-
-    </tr>
-    <tr>
-      <th>E!</th>
-      <th><%= sort_link(@q, :close) %></th>
-      <th>Request date</th>
-      <th>Preferred date</th>
-
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @request_applications.each do |request_application| %>
-    <% current_order = request_application.current_order %>
+<div class="row">
+  <table class="table table-striped">
+    <colgroup>
+      <col class="col-lg-2" />
+      <col class="col-lg-2" />
+      <col class="col-lg-2" />
+      <col class="col-lg-1" />
+      <col class="col-lg-1" />
+      <col class="col-lg-2" />
+      <col class="col-lg-2" />
+    </colgroup>
+    <thead>
       <tr>
-        <td rowspan="2"><%= link_to request_application.management_no, registration_result_request_application_path(request_application) %></td>
-        <td><%= request_application.project.try(:name) %></td>
-        <td><%= request_application.model.try(:code) %></td>
-        <td><%= request_application.section.try(:name) %></td>
-        <td><%= (link_to "Download" , request_application.filename_url) if request_application.filename_url.present? %></td>
-
-        <td rowspan="2">|</td>
-        <% request_application.flows.latest_flows(Flow.latest_ids(request_application.id)).each do |flow| %>
-        <td rowspan="2">
-          <%= ( flow.progress.try(:in_date) || (link_to 'Start', regist_progress_path(request_application), class:"btn btn-warning btn-xs" unless request_application.close?
- )) %><br>
-          <%= ( flow.progress.try(:out_date) || (link_to 'End', regist_memo_path(request_application), class:"btn btn-warning btn-xs"  unless (flow.progress.try(:in_date).blank?  ||  request_application.close?  || current_order != flow.order) ) ) %>
-        </td>
-         <% end %>
-         <% (@flow_orders.count - request_application.flows.maximum(:order)).times do %>
-          <td rowspan="2"></td>
-         <% end %>
-
-        <td rowspan="2"><%= link_to t('.show_request_application_status_detail'), request_application %>
-        <%= (link_to t('template.edit'), edit_request_application_path(request_application)) unless request_application.close? %>
-        <%= (link_to t('template.destroy'), request_application, method: :delete, data: { confirm: 'Are you sure?' })  if request_application.delete_permit? %>
-      </td>
-        <td rowspan="2"><%= link_to t('.reject') , reject_memo_path(request_application) if request_application.flows.order(:history_no).last.reject? %></td>
-        <td rowspan="2"><%= link_to t('.revert') , revert_memo_path(request_application) if request_application.flows.order(:history_no).last.first_to_revert? %></td>
-        <td rowspan="2"><%= link_to t('.interrupt') , interrupt_memo_path(request_application)  if request_application.interrupt_permit? %></td>
-
+        <th><%= t('activerecord.attributes.request_application.management_no') %></th>
+        <th><%= t('activerecord.attributes.request_application.model') %></th>
+        <th><%= t('activerecord.attributes.request_application.section') %></th>
+        <th><%= t('activerecord.attributes.request_application.request_date') %></th>
+        <th><%= t('activerecord.attributes.request_application.preferred_date') %></th>
+        <th><%= t('activerecord.attributes.request_application.file') %></th>
+        <th></th>
       </tr>
-      <tr>
-        <td><%= t('.emargency') if request_application.emargency %></td>
-        <td><%= request_application.close_status %></td>
-        <td><%= request_application.request_date %></td>
-        <td><%= request_application.preferred_date %></td>
-
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @request_applications.each do |request_application| %>
+        <tr>
+          <td><%= request_application.management_no %></td>
+          <td><%= request_application.model&.code %></td>
+          <td><%= request_application.section&.name %></td>
+          <td><%= request_application.request_date %></td>
+          <td><%= request_application.preferred_date %></td>
+          <td><%= (link_to 'Download', request_application.filename_url) if request_application.filename_url.present? %></td>
+          <td>
+            <%= (link_to t('template.edit'), edit_request_application_path(request_application)) %>
+            <%= (link_to t('template.destroy'), request_application, method: :delete, data: { confirm: 'Are you sure?' }) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,11 +25,14 @@ ja:
 
   placeholder:
     partial_match: 部分一致
+    date_long: YYYY/MM/DD
 
   template:
     edit: 編集
     destroy: 削除
     save: 保存
+    search: 検索
+    clear: クリア
 
   link_name:
     request_applications_export_csv: K-PEACEデータ取得用CSV出力

--- a/config/locales/views/request_applications/ja.yml
+++ b/config/locales/views/request_applications/ja.yml
@@ -33,3 +33,5 @@ ja:
       edit_request_application: 要求書情報編集
       add_request_detail: 技術資料詳細を追加
       back: 技術資料要求書一覧画面へ
+    search:
+      search_request_applicaton: 要求書検索

--- a/config/locales/views/request_applications/ja.yml
+++ b/config/locales/views/request_applications/ja.yml
@@ -13,6 +13,8 @@ ja:
       revert: 最初に差戻
       interrupt: 中断
       emargency: 緊急
+      manual_input: 手入力
+      reference: 参照
     new:
       title: 要求書新規受付
       save_and_insert: 詳細入力画面へ


### PR DESCRIPTION
要求書検索の検索項目から削除したのは、
`部署` , `プロジェクト` , `Close` の３つです。

リンクをボタンに変更は別タスクになっているのでそちらで対応します。

画面はこんな感じになります。
![default](https://cloud.githubusercontent.com/assets/21189471/22582500/ac472a4e-ea2a-11e6-8cee-f22648f12f67.png)