### PR TITLE
[sp4-09] DOC TYPE, CHG TYPE のプルダウンに検索を付ける。

### DIFF
--- a/app/assets/javascripts/request_details.coffee
+++ b/app/assets/javascripts/request_details.coffee
@@ -1,0 +1,8 @@
+$(document).on 'turbolinks:load', ->
+  $(".select-doc-type").select2({
+    theme: "bootstrap"
+  })
+
+  $(".select-chg-type").select2({
+    theme: "bootstrap"
+  })

--- a/app/views/request_details/edit.html.erb
+++ b/app/views/request_details/edit.html.erb
@@ -2,7 +2,7 @@
 <%= form_for(@request_detail, url: request_application_request_detail_path, html: { class: 'form-horizontal' }) do |f| %>
   <% if @request_detail.errors.any? %>
     <div id="error_explanation">
-      <h2><%= t('activerecord.errors.template.header', count: @request_detail.errors.messages.length) %></h2>
+      <h2><%= t('activerecord.errors.template.header', count: @request_detail.errors.count) %></h2>
       <ul>
       <% @request_detail.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/request_details/edit.html.erb
+++ b/app/views/request_details/edit.html.erb
@@ -1,8 +1,8 @@
 <h1><%= t('.title') %></h1>
-<%= form_for(@request_detail, url: request_application_request_detail_path) do |f| %>
+<%= form_for(@request_detail, url: request_application_request_detail_path, html: { class: 'form-horizontal' }) do |f| %>
   <% if @request_detail.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(@request_detail.errors.count, "error") %> prohibited this pero from being saved:</h2>
+      <h2><%= t('activerecord.errors.template.header', count: @request_detail.errors.messages.length) %></h2>
       <ul>
       <% @request_detail.errors.full_messages.each do |message| %>
         <li><%= message %></li>
@@ -10,84 +10,84 @@
       </ul>
     </div>
   <% end %>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :doc_no %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :doc_no %>
+      <%= f.text_field :doc_no, class: 'form-control input-sm' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :doc_type %>
     </div>
     <div class="col-lg-3">
-      <%= f.collection_select :doc_type_id, DocType.all, :id, :name %>
+      <%= f.collection_select :doc_type_id, DocType.all, :id, :name, {}, class: 'form-control input-sm select-doc-type' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :sht %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :sht %>
+      <%= f.text_field :sht, class: 'form-control input-sm' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :rev %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :rev %>
+      <%= f.text_field :rev, class: 'form-control input-sm' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :eo_chgno %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :eo_chgno %>
+      <%= f.text_field :eo_chgno, class: 'form-control input-sm' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :chg_type %>
     </div>
     <div class="col-lg-3">
-      <%= f.collection_select :chg_type_id, ChgType.all, :id, :name, include_blank: true %>
+      <%= f.collection_select :chg_type_id, ChgType.order(name: :ASC), :id, :name, { include_blank: true }, class: 'form-control input-sm select-chg-type' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :mcl %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :mcl %>
+      <%= f.text_field :mcl, class: 'form-control input-sm' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :scp_for_smpl %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :scp_for_smpl %>
+      <%= f.text_field :scp_for_smpl, class: 'form-control input-sm' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :scml_ln %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :scml_ln %>
+      <%= f.text_field :scml_ln, class: 'form-control input-sm' %>
     </div>
   </div>
-  <div class="row">
+  <div class="form-group">
     <div class="col-lg-2">
       <%= f.label :vendor_code %>
     </div>
     <div class="col-lg-3">
-      <%= f.text_field :vendor_code %>
+      <%= f.text_field :vendor_code, class: 'form-control input-sm' %>
     </div>
   </div>
   <div class="actions">

--- a/app/views/shared/_application_detail_attributes.html.erb
+++ b/app/views/shared/_application_detail_attributes.html.erb
@@ -10,7 +10,7 @@
           </div>
           <div class="col-lg-2">
             <%= f.label :doc_type %>
-            <%= f.collection_select :doc_type_id, DocType.all, :id, :name, { include_blank: true }, class: 'form-control' %>
+            <%= f.collection_select :doc_type_id, DocType.all, :id, :name, { include_blank: true }, class: 'form-control select-doc-type' %>
           </div>
           <div class="col-lg-2">
             <%= f.label :sht %>
@@ -28,7 +28,7 @@
         <div class="row">
           <div class="col-lg-2">
             <%= f.label :chg_type %>
-            <%= f.collection_select :chg_type_id, ChgType.all, :id, :name, { include_blank: true }, class: 'form-control' %>
+            <%= f.collection_select :chg_type_id, ChgType.order(name: :ASC), :id, :name, { include_blank: true }, class: 'form-control select-chg-type' %>
           </div>
           <div class="col-lg-2">
             <%= f.label :mcl %>


### PR DESCRIPTION
プルダウンの表示順は下記の通り
・DOC TYPE は並び替えしない(id順のまま)
・CHG TYPE はアルファベット順でソート

技術資料詳細編集にプルダウン検索を付ける際に一緒に bootstrap もあててます。
![default](https://cloud.githubusercontent.com/assets/21189471/22585848/35c7d2d4-ea3d-11e6-9238-e7da6baf9726.png)
