### PR TITLE
[sp1-02] #TK-01158 リコンサイル結果で一致した情報をCSV出力

### DIFF
--- a/app/controllers/request_applications/matching_controller.rb
+++ b/app/controllers/request_applications/matching_controller.rb
@@ -11,7 +11,7 @@ class RequestApplications::MatchingController < ApplicationController
         @matching_results = @request_application.compare_to_matching_datas
       end
       format.csv do
-        send_data @request_application.export_matching_result_csv, type: 'text/csv; charset=shift_jis', filename: "#{Time.zone.now.to_date}.csv"
+        send_data @request_application.export_matching_result_csv, type: 'text/csv; charset=shift_jis', filename: "#{t('file_name.matching_result_export_csv')}_#{Time.zone.now.to_date}.csv"
       end
     end
   end

--- a/app/controllers/request_applications/matching_controller.rb
+++ b/app/controllers/request_applications/matching_controller.rb
@@ -11,7 +11,7 @@ class RequestApplications::MatchingController < ApplicationController
         @matching_results = @request_application.compare_to_matching_datas
       end
       format.csv do
-        send_data @request_application.export_matching_result_csv, type: 'text/csv; charset=shift_jis', filename: "#{t('file_name.matching_result_export_csv')}_#{Time.zone.now.to_date}.csv"
+        send_data @request_application.export_matching_result_csv, type: 'text/csv; charset=shift_jis', filename: "#{t('file_name.matching_result_export_csv')}_#{Time.zone.today}.csv"
       end
     end
   end

--- a/app/controllers/request_applications/matching_controller.rb
+++ b/app/controllers/request_applications/matching_controller.rb
@@ -6,6 +6,13 @@ class RequestApplications::MatchingController < ApplicationController
 
   def matching_result
     @request_application = RequestApplication.find(params[:id])
-    @matching_results = @request_application.compare_to_matching_datas
+    respond_to do |format|
+      format.html do
+        @matching_results = @request_application.compare_to_matching_datas
+      end
+      format.csv do
+        send_data @request_application.export_matching_result_csv, type: 'text/csv; charset=shift_jis', filename: "#{Time.zone.now.to_date}.csv"
+      end
+    end
   end
 end

--- a/app/models/request_application.rb
+++ b/app/models/request_application.rb
@@ -1,5 +1,6 @@
 class RequestApplication < ActiveRecord::Base
   include RequestApplication::Matcher
+  include RequestApplication::MatcherExportCsv
 
   has_many :flows, dependent: :destroy
   has_many :details, class_name: 'RequestDetail', dependent: :destroy

--- a/app/models/request_application/matcher_export_csv.rb
+++ b/app/models/request_application/matcher_export_csv.rb
@@ -60,19 +60,23 @@ module RequestApplication::MatcherExportCsv
   end
 
   def matched_values
-    target_details = details.includes(:doc_type, :chg_type).order(doc_no: :ASC)
     target_for_matching_datas = ForMatchingData.where(model_code: model.code).order(doc_no: :ASC).to_a
-    target_details.map do |detail|
+    details.includes(:doc_type, :chg_type).order(doc_no: :ASC).map do |detail|
       values = {}
       target_for_matching_datas.delete_if do |for_matching_data|
         if detail.compare_attributes == for_matching_data.compare_attributes
-          values[:format_type] = for_matching_data.format_type
-          values[:document_no] = for_matching_data.document_no
-          values[:revision] = for_matching_data.revision
-          values[:vendor_code] = detail.vendor_code
+          set_values(values, detail, for_matching_data)
+          true
         end
       end
       values.present? ? values : nil
     end.compact
+  end
+
+  def set_values(values, detail, for_matching_data)
+    values[:format_type] = for_matching_data.format_type
+    values[:document_no] = for_matching_data.document_no
+    values[:revision] = for_matching_data.revision
+    values[:vendor_code] = detail.vendor_code
   end
 end

--- a/app/models/request_application/matcher_export_csv.rb
+++ b/app/models/request_application/matcher_export_csv.rb
@@ -1,0 +1,78 @@
+module RequestApplication::MatcherExportCsv
+
+  HEADER = [
+    '種類',
+    'ドキュメント番号',
+    'リビジョン',
+    'SHEET枚数',
+    'ステータス',
+    '配付区分',
+    'CONTROL COPY NO',
+    '配付先',
+    '配付要求課（資材）',
+    'REL日',
+    '配付指示日',
+    '受領日',
+    '返却日',
+    '配付状態',
+    'ドキュメント名称',
+    '参考情報',
+    'ドキュメント・サイズ（原寸）',
+    'サイズ、枚数（混在パターン）',
+    '印刷縮尺',
+    '部数',
+    '配付方式',
+    'サブコンコード（設計分担）',
+    'サブコンコード（製造分担）',
+    '複製用W/O',
+    '点検承認PKG番号',
+    '発行条件',
+    '配付備考',
+    '配付トリガー',
+    '配付情報確定日',
+    'プラングループ',
+    'セキュリティコード',
+    'OID1',
+    'OID2'
+  ].freeze
+
+  ROW_ATTRIBUTES = {
+    '種類' => :format_type,
+    'ドキュメント番号' => :document_no,
+    'リビジョン' => :revision,
+    '配付先' => :vendor_code
+  }.freeze
+
+  def export_matching_result_csv
+    CSV.generate(headers: HEADER, write_headers: true) do |csv|
+      matched_rows.each { |row| csv << row }
+    end.encode(Encoding::SJIS)
+  end
+
+  private
+
+  def matched_rows
+    matched_values.map do |value|
+      HEADER.map do |name|
+        value[ROW_ATTRIBUTES[name]] if ROW_ATTRIBUTES.key?(name)
+      end
+    end
+  end
+
+  def matched_values
+    target_details = details.includes(:doc_type, :chg_type).order(doc_no: :ASC)
+    target_for_matching_datas = ForMatchingData.where(model_code: model.code).order(doc_no: :ASC).to_a
+    target_details.map do |detail|
+      values = {}
+      target_for_matching_datas.delete_if do |for_matching_data|
+        if detail.compare_attributes == for_matching_data.compare_attributes
+          values[:format_type] = for_matching_data.format_type
+          values[:document_no] = for_matching_data.document_no
+          values[:revision] = for_matching_data.revision
+          values[:vendor_code] = detail.vendor_code
+        end
+      end
+      values.present? ? values : nil
+    end.compact
+  end
+end

--- a/app/models/request_application/matcher_export_csv.rb
+++ b/app/models/request_application/matcher_export_csv.rb
@@ -60,14 +60,13 @@ module RequestApplication::MatcherExportCsv
   end
 
   def matched_values
-    target_for_matching_datas = ForMatchingData.where(model_code: model.code).order(doc_no: :ASC).to_a
+    target_for_matching_datas = ForMatchingData.where(model_code: model.code).order(doc_no: :ASC)
     details.includes(:doc_type, :chg_type).order(doc_no: :ASC).map do |detail|
       values = {}
-      target_for_matching_datas.delete_if do |for_matching_data|
-        if detail.compare_attributes == for_matching_data.compare_attributes
-          set_values(values, detail, for_matching_data)
-          true
-        end
+      target_for_matching_datas.each do |for_matching_data|
+        next unless detail.compare_attributes == for_matching_data.compare_attributes
+        set_values(values, detail, for_matching_data)
+        break
       end
       values.present? ? values : nil
     end.compact

--- a/app/models/request_application/matcher_export_csv.rb
+++ b/app/models/request_application/matcher_export_csv.rb
@@ -60,22 +60,24 @@ module RequestApplication::MatcherExportCsv
   end
 
   def matched_values
-    target_for_matching_datas = ForMatchingData.where(model_code: model.code).order(doc_no: :ASC)
-    details.includes(:doc_type, :chg_type).order(doc_no: :ASC).map do |detail|
-      values = {}
-      target_for_matching_datas.each do |for_matching_data|
-        next unless detail.compare_attributes == for_matching_data.compare_attributes
-        set_values(values, detail, for_matching_data)
-        break
+    [].tap do |values|
+      details.includes(:doc_type, :chg_type).order(doc_no: :ASC).map do |detail|
+        ForMatchingData.where(model_code: model.code).order(doc_no: :ASC).each do |for_matching_data|
+          if detail.compare_attributes == for_matching_data.compare_attributes
+            values << matched_value(detail, for_matching_data)
+            break
+          end
+        end
       end
-      values.present? ? values : nil
-    end.compact
+    end
   end
 
-  def set_values(values, detail, for_matching_data)
-    values[:format_type] = for_matching_data.format_type
-    values[:document_no] = for_matching_data.document_no
-    values[:revision] = for_matching_data.revision
-    values[:vendor_code] = detail.vendor_code
+  def matched_value(detail, for_matching_data)
+    {
+      format_type: for_matching_data.format_type,
+      document_no: for_matching_data.document_no,
+      revision: for_matching_data.revision,
+      vendor_code: detail.vendor_code
+    }
   end
 end

--- a/app/views/request_applications/matching/matching_result.html.erb
+++ b/app/views/request_applications/matching/matching_result.html.erb
@@ -9,7 +9,6 @@
       <%= link_to t('.rerun'), matching_result_request_application_path(@request_application), class: 'btn btn-primary' %>
     </div>
   </div>
-
   <div class="table-responsive">
     <table class="table table-bordered table-hover">
       <colgroup>
@@ -42,5 +41,19 @@
   </div>
 </div>
 <div class="row">
-  <%= link_to t('.back'), request_applications_path %>
+  <div class="panel panel-default">
+    <div class="panel-heading"><%= t('.csv_export_title') %></div>
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-lg-12">
+          <%= link_to t('.csv_export'), matching_result_request_application_path(@request_application, format: 'csv'), class: 'btn btn-primary' %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-lg-12">
+    <%= link_to t('.back'), request_applications_path %>
+  </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -48,3 +48,5 @@ ja:
     flow_orders: フロー順登録
     chg_types: CHG TYPE
     doc_types: DOC TYPE
+  file_name:
+    matching_result_export_csv: K-PEACEインプット用CSVファイル

--- a/config/locales/views/request_applications/matching/ja.yml
+++ b/config/locales/views/request_applications/matching/ja.yml
@@ -16,3 +16,5 @@ ja:
         unmatch: 不一致
         back: 技術資料要求書一覧画面へ
         rerun: 再実行
+        csv_export_title: K-PEACEインプット用CSVファイル出力
+        csv_export: CSV出力


### PR DESCRIPTION
CSV出力ボタンは下記バックログに通りに置いてみましたがちょっと違和感。
```
・リコンサイル結果画面の下部に「K-PEACEインプット用CSVファイル出力」というラベルがある枠を作る。
・枠内に「CSV出力」ボタンを作る
```
戻るリンクをテーブル上部にもってくればもう少しましにはなるかと思います。

#82 からブランチ切ったので先にそちらをマージして頂けると変更箇所が見やすくなるかと…
![csv](https://cloud.githubusercontent.com/assets/21189471/22732356/3f44adbc-ee31-11e6-9764-2a1390f733ec.png)
