### PR TITLE
[sp4-ex1] #TK-01160 技術資料詳細入力のDOCTYPEだけ項目名の背景が赤くならない

### DIFF
--- a/app/views/request_details/edit.html.erb
+++ b/app/views/request_details/edit.html.erb
@@ -20,7 +20,7 @@
   </div>
   <div class="form-group">
     <div class="col-lg-2">
-      <%= f.label :doc_type %>
+      <%= f.label :doc_type_id %>
     </div>
     <div class="col-lg-3">
       <%= f.collection_select :doc_type_id, DocType.all, :id, :name, {}, class: 'form-control input-sm select-doc-type' %>

--- a/app/views/shared/_application_detail_attributes.html.erb
+++ b/app/views/shared/_application_detail_attributes.html.erb
@@ -9,7 +9,7 @@
             <%= f.text_field :doc_no, class: 'form-control' %>
           </div>
           <div class="col-lg-2">
-            <%= f.label :doc_type %>
+            <%= f.label :doc_type_id %>
             <%= f.collection_select :doc_type_id, DocType.all, :id, :name, { include_blank: true }, class: 'form-control select-doc-type' %>
           </div>
           <div class="col-lg-2">

--- a/config/locales/models/request_detail/ja.yml
+++ b/config/locales/models/request_detail/ja.yml
@@ -14,3 +14,4 @@ ja:
         vendor_code: V/C
         doc_type: DOC TYPE
         chg_type: CHG TYPE
+        doc_type_id: DOC TYPE


### PR DESCRIPTION
validateに通らなかった時にform部分が赤くならないのを修正

before
![doc_type_before](https://cloud.githubusercontent.com/assets/21189471/22733938/29b1d3a2-ee37-11e6-94db-4982c78575f1.png)

after
![doc_type_after](https://cloud.githubusercontent.com/assets/21189471/22733944/2f2d14c2-ee37-11e6-9b89-cae3c53ec61c.png)
