### PR TITLE
[sp4-ex3] #TK-01170 POから要望があった画面レイアウトへ修正

### DIFF
--- a/app/assets/stylesheets/request_applications.scss
+++ b/app/assets/stylesheets/request_applications.scss
@@ -33,8 +33,8 @@ input.clicked {
   margin-left: 10px;
 }
 
-.search-btn-row {
-  margin-top: 15px;
+.search-btn {
+  padding-top: 22px;
 }
 
 .between-label {

--- a/app/views/request_applications/_search.html.erb
+++ b/app/views/request_applications/_search.html.erb
@@ -22,9 +22,7 @@
               <%= f.collection_select :section_id_eq, Section.all, :id, :name, { include_blank: true } , class: 'form-control input-sm' %>
             </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="col-sm-12">
+          <div class="col-sm-4">
             <%= f.label :preferred_date %>
             <div class="form-inline">
               <%= f.text_field :preferred_date_gteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
@@ -32,11 +30,11 @@
               <%= f.text_field :preferred_date_lteq, placeholder: t('placeholder.date_long'), class: 'form-control input-sm datetimepicker' %>
             </div>
           </div>
-        </div>
-        <div class="row search-btn-row">
-          <div class="col-sm-12">
-            <%= f.submit t('template.search'), class: 'btn btn-primary' %>
-            <%= link_to t('template.clear'), url_for, class: 'btn btn-default' %>
+          <div class="col-sm-2">
+            <div class="search-btn">
+              <%= f.submit t('template.search'), class: 'btn btn-primary' %>
+              <%= link_to t('template.clear'), url_for, class: 'btn btn-default' %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/request_details/new.html.erb
+++ b/app/views/request_details/new.html.erb
@@ -7,11 +7,9 @@
     <%= link_to t('.edit_request_application'), edit_request_application_path(@request_application), class: 'btn btn-primary' %>
   </div>
 </div>
-<%= render partial: 'shared/application_details_table', locals: { request_application: @request_application } %>
-
 <%= form_for(@request_detail, url: request_application_request_details_path) do |f| %>
   <%= render partial: 'shared/application_detail_attributes', locals: { f: f } %>
-  <div class="row">
+  <div class="row btn-row">
     <div class="actions">
       <%= f.submit t('.save_and_insert'), class:"btn btn-primary", name: 'save_and_insert' %>
       <%= f.submit t('template.save'), class:"btn btn-secondary", name: 'end_regist' %>
@@ -19,3 +17,5 @@
     </div>
   </div>
 <% end %>
+
+<%= render partial: 'shared/application_details_table', locals: { request_application: @request_application } %>

--- a/app/views/shared/_application_details_table.html.erb
+++ b/app/views/shared/_application_details_table.html.erb
@@ -34,7 +34,7 @@
             <td><%= detail.vendor_code %></td>
             <td><%= link_to t('template.edit'), edit_request_application_request_detail_path(request_application, detail), class: 'btn btn-primary btn-sm' %></td>
             <% unless from_edit_request_application? %>
-              <td><%= link_to t('template.destroy'), request_application_request_detail_path(request_application, detail), method: :delete, data: { confirm: t('message.template.delete.confirm') }, class: 'btn btn-warning btn-sm' %></td>
+              <td><%= link_to t('template.destroy'), request_application_request_detail_path(request_application, detail), method: :delete, data: { confirm: t('message.template.delete.confirm') }, class: 'btn btn-danger btn-sm' %></td>
             <% end %>
           </tr>
         <% end %>


### PR DESCRIPTION
```
　5.2. Ｄ(技術資料詳細入力)画面の詳細を入力する為のエリアの位置
　　⇒ (5.1. と併せて)一覧表の上部にしませんか？
⇒(回答)上部に変更してください。Ｆ:技術資料詳細編集も同様。
追加する時に毎度スクロールしてからでは手間だと判断しました。

[削除]ボタンの色がオレンジになっている。
```
F画面(技術資料詳細編集)は一覧表とは別の画面なのでそのままに。
[削除]ボタンの色を他と合わせ赤に変更。

![default](https://cloud.githubusercontent.com/assets/21189471/22957822/5414525a-f36e-11e6-8374-9238150e77f3.png)


```
技術資料要求書一覧画面の要求書検索ウィンドウの検索キーの並びを、２段から1段にして上下の幅を狭くして頂くことはできますか？
（要求元欄の右側に入手希望日欄を表示して1列に収めることができないかなと思っています。
さらに、一番右側に検索/クリアボタンも並べることができると1列ですっきりするのでは？と思っています。）
```
上記に従い一段に変更。

![default](https://cloud.githubusercontent.com/assets/21189471/22957726/9abfa28c-f36d-11e6-84c0-7e499688db18.png)
