### PR TITLE
[sp4-ex3] #TK-01172 技術詳細入力画面のボタン位置変更

### DIFF
--- a/app/assets/stylesheets/request_details.scss
+++ b/app/assets/stylesheets/request_details.scss
@@ -1,0 +1,3 @@
+.detail-form-btn {
+  padding-top: 22px;
+}

--- a/app/views/request_details/new.html.erb
+++ b/app/views/request_details/new.html.erb
@@ -9,13 +9,6 @@
 </div>
 <%= form_for(@request_detail, url: request_application_request_details_path) do |f| %>
   <%= render partial: 'shared/application_detail_attributes', locals: { f: f } %>
-  <div class="row btn-row">
-    <div class="actions">
-      <%= f.submit t('.save_and_insert'), class:"btn btn-primary", name: 'save_and_insert' %>
-      <%= f.submit t('template.save'), class:"btn btn-secondary", name: 'end_regist' %>
-      <%= link_to t('.cancel'), registration_result_request_application_path(@request_application), class:"btn btn-default" %>
-    </div>
-  </div>
 <% end %>
 
 <%= render partial: 'shared/application_details_table', locals: { request_application: @request_application } %>

--- a/app/views/shared/_application_detail_attributes.html.erb
+++ b/app/views/shared/_application_detail_attributes.html.erb
@@ -47,7 +47,7 @@
           <%= f.text_field :vendor_code, class: 'form-control'  %>
         </div>
         <div class="col-lg-4">
-          <div class="actions detail-form-btn">
+          <div class="actions detail-form-btn pull-right">
             <%= f.submit t('.save_and_insert'), class:"btn btn-primary", name: 'save_and_insert' %>
             <%= f.submit t('template.save'), class:"btn btn-secondary", name: 'end_regist' %>
             <%= link_to t('template.cancel'), registration_result_request_application_path(@request_application), class:"btn btn-default" %>

--- a/app/views/shared/_application_detail_attributes.html.erb
+++ b/app/views/shared/_application_detail_attributes.html.erb
@@ -2,51 +2,58 @@
   <div class="panel panel-default">
     <div class="panel-heading"><%= t('activerecord.models.request_detail') %></div>
     <div class="panel-body">
-        <div class="row">
-          <%= f.hidden_field :request_application_id %>
-          <div class="col-lg-2">
-            <%= f.label :doc_no %>
-            <%= f.text_field :doc_no, class: 'form-control' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :doc_type_id %>
-            <%= f.collection_select :doc_type_id, DocType.all, :id, :name, { include_blank: true }, class: 'form-control select-doc-type' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :sht %>
-            <%= f.text_field :sht, class: 'form-control' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :rev %>
-            <%= f.text_field :rev, class: 'form-control' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :eo_chgno %>
-            <%= f.text_field :eo_chgno, class: 'form-control' %>
+      <div class="row">
+        <%= f.hidden_field :request_application_id %>
+        <div class="col-lg-2">
+          <%= f.label :doc_no %>
+          <%= f.text_field :doc_no, class: 'form-control' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :doc_type_id %>
+          <%= f.collection_select :doc_type_id, DocType.all, :id, :name, { include_blank: true }, class: 'form-control select-doc-type' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :sht %>
+          <%= f.text_field :sht, class: 'form-control' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :rev %>
+          <%= f.text_field :rev, class: 'form-control' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :eo_chgno %>
+          <%= f.text_field :eo_chgno, class: 'form-control' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :chg_type %>
+          <%= f.collection_select :chg_type_id, ChgType.order(name: :ASC), :id, :name, { include_blank: true }, class: 'form-control select-chg-type' %>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-lg-2">
+          <%= f.label :mcl %>
+          <%= f.text_field :mcl, class: 'form-control' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :scp_for_smpl %>
+          <%= f.text_field :scp_for_smpl, class: 'form-control' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :scml_ln %>
+          <%= f.text_field :scml_ln, class: 'form-control' %>
+        </div>
+        <div class="col-lg-2">
+          <%= f.label :vendor_code %>
+          <%= f.text_field :vendor_code, class: 'form-control'  %>
+        </div>
+        <div class="col-lg-4">
+          <div class="actions detail-form-btn">
+            <%= f.submit t('.save_and_insert'), class:"btn btn-primary", name: 'save_and_insert' %>
+            <%= f.submit t('template.save'), class:"btn btn-secondary", name: 'end_regist' %>
+            <%= link_to t('template.cancel'), registration_result_request_application_path(@request_application), class:"btn btn-default" %>
           </div>
         </div>
-        <div class="row">
-          <div class="col-lg-2">
-            <%= f.label :chg_type %>
-            <%= f.collection_select :chg_type_id, ChgType.order(name: :ASC), :id, :name, { include_blank: true }, class: 'form-control select-chg-type' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :mcl %>
-            <%= f.text_field :mcl, class: 'form-control' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :scp_for_smpl %>
-            <%= f.text_field :scp_for_smpl, class: 'form-control' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :scml_ln %>
-            <%= f.text_field :scml_ln, class: 'form-control' %>
-          </div>
-          <div class="col-lg-2">
-            <%= f.label :vendor_code %>
-            <%= f.text_field :vendor_code, class: 'form-control'  %>
-          </div>
-        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -36,6 +36,7 @@ ja:
     search: 検索
     clear: クリア
     reference: 参照
+    cancel: キャンセル
 
   link_name:
     request_applications_export_csv: K-PEACEデータ取得用CSV出力

--- a/config/locales/views/request_details/ja.yml
+++ b/config/locales/views/request_details/ja.yml
@@ -3,7 +3,6 @@ ja:
     new:
       title: 技術資料詳細入力
       edit_request_application: 要求書情報編集
-      save_and_insert: もう1件入力
       cancel: キャンセル
       back: 技術資料要求書一覧画面へ
     show:

--- a/config/locales/views/shared/application_detail_attributes/ja.yml
+++ b/config/locales/views/shared/application_detail_attributes/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  shared:
+    application_detail_attributes:
+      save_and_insert: もう1件入力


### PR DESCRIPTION
頂いた要望を踏まえ変更しました。
```
技術資料詳細追加に関連するボタンを枠内に収めることはできますか？
その際、CHG TYPEは上段に移設したうえで枠内のムダな余白が発生しないようにしたいです。
```
こんな感じになります。
![default](https://cloud.githubusercontent.com/assets/21189471/22967092/633364d0-f3a8-11e6-9ab1-69c1381262a6.png)
