### PR TITLE
[sp4-ex3] #TK-01175 B,D画面の「保存」ボタンの見た目をボタン感が出るように変更

### DIFF
--- a/app/assets/stylesheets/request_details.scss
+++ b/app/assets/stylesheets/request_details.scss
@@ -1,3 +1,7 @@
 .detail-form-btn {
   padding-top: 22px;
 }
+
+.btn-secondary-border {
+  border: 1px solid #808080;
+}

--- a/app/views/shared/_application_detail_attributes.html.erb
+++ b/app/views/shared/_application_detail_attributes.html.erb
@@ -49,7 +49,7 @@
         <div class="col-lg-4">
           <div class="actions detail-form-btn pull-right">
             <%= f.submit t('.save_and_insert'), class:"btn btn-primary", name: 'save_and_insert' %>
-            <%= f.submit t('template.save'), class:"btn btn-secondary", name: 'end_regist' %>
+            <%= f.submit t('template.save'), class:"btn btn-secondary btn-secondary-border", name: 'end_regist' %>
             <%= link_to t('template.cancel'), registration_result_request_application_path(@request_application), class:"btn btn-default" %>
           </div>
         </div>


### PR DESCRIPTION
```
Ｂ画面(新規要求書受付)、Ｄ画面(技術資料 詳細入力)にある、
「保存」ボタン(グレーの薄 いヤツ)に、やや濃いめの枠線を付けて欲しい。
ボタンがそこにあることがわかりにくいため、多少の存在感を出して欲しい。
```
上記に従い、ボタン感が出るように枠線追加。

before
![2017-02-20 16 00 56](https://cloud.githubusercontent.com/assets/21189471/23115159/729285d2-f786-11e6-8ed2-e0d4cbf282f1.png)

after
![2017-02-20 16 01 08](https://cloud.githubusercontent.com/assets/21189471/23115165/77f32c20-f786-11e6-9631-28f385b90bcf.png)
