### PR TITLE
[sp4-ex3] #TK-01173 Ｈ画面(要求書＆技術資料詳細)の一覧の上に一覧の件数を表示

### DIFF
--- a/app/views/request_applications/registration_result.html.erb
+++ b/app/views/request_applications/registration_result.html.erb
@@ -7,7 +7,9 @@
     <%= link_to t('.edit_request_application'), edit_request_application_path(@request_application), class: 'btn btn-primary' %>
   </div>
 </div>
-
+<div class="row">
+  <b><%= t('.document_count', count: @request_application.details.count) %></b>
+</div>
 <%= render partial: 'shared/application_details_table', locals: { request_application: @request_application } %>
 
 <div class="row btn-row">

--- a/config/locales/views/request_applications/ja.yml
+++ b/config/locales/views/request_applications/ja.yml
@@ -32,5 +32,6 @@ ja:
       edit_request_application: 要求書情報編集
       add_request_detail: 技術資料詳細を追加
       back: 技術資料要求書一覧画面へ
+      document_count: "ドキュメント数：%{count}"
     search:
       search_request_applicaton: 要求書検索


### PR DESCRIPTION
要望だと表示するのはH画面だけになっていましたが、
```
D画面(技術資料詳細入力)　※入力している際に何件登録したか把握する必要有り？
E画面(要求書情報編集)　　※要求書の編集なので不要とは思いますが。
```
H画面と似たレイアウトの上記画面には不要という認識でOKでしょうか？

H画面はこんな感じになります。
ちょっと見た目がシンプルすぎるかも…？
![default](https://cloud.githubusercontent.com/assets/21189471/23115519/a31860ee-f788-11e6-89b2-678a135cada1.png)
