### PR TITLE
[sp4-ex3] #TK-01176 要求書管理情報の入力でエラー時にレイアウトがずれるのを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,9 +34,18 @@ p, ol, ul, td {
 }
 
 .field_with_errors {
-  padding: 2px;
-  background-color: red;
-  display: table;
+  label {
+    background-color: red;
+  }
+  select {
+    border: 2px solid red;
+  }
+  input {
+    border: 2px solid red;
+  }
+  .select2-selection {
+    border: 2px solid red;
+  }
 }
 
 #error_explanation {

--- a/app/models/request_application.rb
+++ b/app/models/request_application.rb
@@ -10,8 +10,8 @@ class RequestApplication < ActiveRecord::Base
   mount_uploader :filename, FileUploader
 
   validates :management_no, uniqueness: true, presence: true
-  validates :model, presence: true
-  validates :section, presence: true
+  validates :model_id, presence: true
+  validates :section_id, presence: true
   validates :request_date, presence: true
   validates :preferred_date, presence: true
 

--- a/app/views/request_applications/new.html.erb
+++ b/app/views/request_applications/new.html.erb
@@ -7,7 +7,7 @@
       <%= render partial: 'shared/request_application_attributes', locals: { f: f } %>
       <div class="actions">
         <%= f.submit t('.save_and_insert'), class:"btn btn-primary", name: 'save_and_insert' %>
-        <%= f.submit t('template.save'), class:"btn btn-secondary", name: 'end_regist' %>
+        <%= f.submit t('template.save'), class:"btn btn-secondary btn-secondary-border", name: 'end_regist' %>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/_request_application_attributes.html.erb
+++ b/app/views/shared/_request_application_attributes.html.erb
@@ -1,42 +1,42 @@
 <div class="form-group">
   <div class="row">
     <div class="col-lg-2">
-      <%= f.label :management_no %><br>
-      <%= f.text_field :management_no, class: 'form-control input-sm' %>
+      <div><%= f.label :management_no %></div>
+      <div><%= f.text_field :management_no, class: 'form-control input-sm' %></div>
     </div>
     <div class="col-lg-2">
-      <%= f.label :project %><br>
-      <%= f.collection_select :project_id, Project.all, :id, :name, { include_blank: true }, class: 'form-control input-sm' %>
+      <div><%= f.label :project %></div>
+      <div><%= f.collection_select :project_id, Project.all, :id, :name, { include_blank: true }, class: 'form-control input-sm' %></div>
     </div>
     <div class="col-lg-2">
-      <%= f.label :model %><br>
-      <%= f.collection_select :model_id, Model.order(code: :ASC), :id, :code, { include_blank: true }, class: 'form-control input-sm select-model'  %>
+      <div><%= f.label :model_id %></div>
+      <div><%= f.collection_select :model_id, Model.order(code: :ASC), :id, :code, { include_blank: true }, class: 'form-control input-sm select-model'  %></div>
     </div>
     <div class="col-lg-2">
-      <%= f.label :section %><br>
-      <%= f.collection_select :section_id, Section.all, :id, :name, { include_blank: true }, class: 'form-control input-sm'  %>
+      <div><%= f.label :section_id %></div>
+      <div><%= f.collection_select :section_id, Section.all, :id, :name, { include_blank: true }, class: 'form-control input-sm'  %></div>
     </div>
     <div class="col-lg-4">
-      <%= f.label :emargency %><br>
-      <%= f.check_box :emargency, class: 'checkbox' %>
+      <div><%= f.label :emargency %></div>
+      <div><%= f.check_box :emargency, class: 'checkbox' %></div>
     </div>
   </div>
   <div class="row">
     <div class="col-lg-3">
-      <%= f.label :filename %><br>
-      <%= f.file_field :filename %>
+      <div><%= f.label :filename %></div>
+      <div><%= f.file_field :filename %></div>
     </div>
     <div class="col-lg-3 form-inline">
-      <%= f.label :request_date %><br>
-      <%= f.text_field :request_date, placeholder: 'YYYY/MM/DD', class: 'form-control input-sm datetimepicker' %>
+      <div><%= f.label :request_date %></div>
+      <div><%= f.text_field :request_date, placeholder: 'YYYY/MM/DD', class: 'form-control input-sm datetimepicker' %></div>
     </div>
     <div class="col-lg-3 form-inline">
-      <%= f.label :preferred_date %><br>
-      <%= f.text_field :preferred_date, placeholder: 'YYYY/MM/DD', class: 'form-control input-sm datetimepicker' %>
+      <div><%= f.label :preferred_date %></div>
+      <div><%= f.text_field :preferred_date, placeholder: 'YYYY/MM/DD', class: 'form-control input-sm datetimepicker' %></div>
     </div>
     <div class="col-lg-3">
-      <%= f.label :memo %><br>
-      <%= f.text_area :memo, class: 'form-control input-sm' %>
+      <div><%= f.label :memo %></div>
+      <div><%= f.text_area :memo, class: 'form-control input-sm' %></div>
     </div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module DenshowQuick
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    #デフォルトだとdivタグで挟まれてレイアウト崩れるのでspanタグに変更
+    config.action_view.field_error_proc = proc do |html_tag, _instance|
+      %(<span class="field_with_errors">#{html_tag}</span>).html_safe
+    end
   end
 end

--- a/config/locales/models/request_application/ja.yml
+++ b/config/locales/models/request_application/ja.yml
@@ -6,7 +6,9 @@ ja:
       request_application:
         management_no: 要求元整理番号
         model: 機種コード
+        model_id: 機種コード
         section: 要求元
+        section_id: 要求元
         request_date: 要求日
         preferred_date: 入手希望日
         emargency: 緊急

--- a/spec/models/request_application_spec.rb
+++ b/spec/models/request_application_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe RequestApplication, type: :model do
   end
 
   describe 'validates' do
+    subject { request_application.valid? }
+
     let(:request_application) do
       create(
         :request_application,
@@ -25,8 +27,6 @@ RSpec.describe RequestApplication, type: :model do
     end
 
     describe '日付の前後関係' do
-      subject { request_application.valid? }
-
       before do
         request_application.request_date = Time.zone.today
         request_application.preferred_date = preferred_date
@@ -51,6 +51,32 @@ RSpec.describe RequestApplication, type: :model do
         it do
           is_expected.to be_falsey
         end
+      end
+    end
+
+    %i(management_no model_id section_id request_date preferred_date).each do |attribute|
+      describe "#{attribute} presence validate" do
+        context '値がnilの場合' do
+          before { request_application[attribute] = nil }
+          it do
+            is_expected.to be_falsey
+          end
+        end
+      end
+    end
+
+    describe 'management_no' do
+      context '値がユニークではない場合' do
+        subject { same_attribute_request_application.valid? }
+
+        let(:same_attribute_request_application) do
+          build(
+            :request_application,
+            request_application.attributes
+          )
+        end
+
+        it { is_expected.to be_falsey }
       end
     end
   end


### PR DESCRIPTION
field_with_errosを弄ったので他画面に影響出ていますが、
他画面の対応含めるとファイルが多くなりすぎるので別PRで対応します。

間違って https://github.com/ogis-Yamada-Shizuka/denshow-quick/pull/107 からブランチ切ってしまったので、あちらがマージされたらこっちをマージします…

画面はこんな感じになります。
to 山田さん
保存ボタンこんな感じですが、見やすさ的に大丈夫ですかね？
![2px](https://cloud.githubusercontent.com/assets/21189471/23118784/b9905326-f798-11e6-880c-f2af9521b01c.png)

