### PR TITLE
リコンサイルのattribute比較用メソッドのテストコード追加

### DIFF
--- a/spec/models/for_matching_data_spec.rb
+++ b/spec/models/for_matching_data_spec.rb
@@ -43,4 +43,63 @@ RSpec.describe ForMatchingData, type: :model do
       end
     end
   end
+
+  describe 'compare_attributes method' do
+    let(:attributes) do
+      {
+        doc_no: 'DOC-TEST-001',
+        doc_type: 'GHI',
+        sht: 'S01',
+        rev: 'A',
+        eo_chgno: 'N99',
+        chg_type: 'BVSR',
+        mcl: '(D)',
+        scp_for_smpl: 'ｲ-6#2',
+        scml_ln: 'A-N'
+      }
+    end
+
+    let(:for_matching_data) do
+      create(
+        :for_matching_data,
+        doc_no: attributes[:doc_no], doc_type_str: attributes[:doc_type],
+        sht: attributes[:sht], eo_chgno: attributes[:eo_chgno],
+        chg_type_str: attributes[:chg_type], mcl: attributes[:mcl],
+        scp_for_smpl: attributes[:scp_for_smpl], scml: attributes[:scml_ln]
+      )
+    end
+
+    describe 'attributesに設定した値が規定のキーと値で返却される' do
+      subject { for_matching_data.compare_attributes }
+      it { is_expected.to eq attributes }
+    end
+
+    describe '返却される key の rev の値は revision に設定した値が返却される' do
+      subject { for_matching_data.compare_attributes[:rev] }
+      before do
+        build(:for_matching_data, rev: 'rev', revision: 'revision')
+      end
+
+      it { is_expected.to eq for_matching_data.revision }
+    end
+
+    describe '同一の値を設定した RequestDetail と比較すると True が得られる' do
+      subject { for_matching_data.compare_attributes == request_detail.compare_attributes }
+      let(:request_application) { create(:request_application, model: create(:model), section: create(:section)) }
+
+      let(:request_detail) do
+        create(
+          :request_detail,
+          request_application: request_application, doc_no: attributes[:doc_no],
+          sht: attributes[:sht], rev: attributes[:rev],
+          eo_chgno: attributes[:eo_chgno], mcl: attributes[:mcl],
+          scp_for_smpl: attributes[:scp_for_smpl], scml_ln: attributes[:scml_ln],
+          doc_type: create(:doc_type, name: attributes[:doc_type]),
+          chg_type: create(:chg_type, name: attributes[:chg_type])
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/for_matching_data_spec.rb
+++ b/spec/models/for_matching_data_spec.rb
@@ -74,6 +74,17 @@ RSpec.describe ForMatchingData, type: :model do
       it { is_expected.to eq attributes }
     end
 
+    describe '値が nil もしくは 空文字 の場合は該当するキーが返却されない' do
+      before do
+        build(:for_matching_data, doc_no: nil, sht: '')
+      end
+
+      %i(doc_no sht).each do |key|
+        subject { for_matching_data.compare_attributes.key?(key) }
+        it { is_expected.to be_truthy }
+      end
+    end
+
     describe '返却される key の rev の値は revision に設定した値が返却される' do
       subject { for_matching_data.compare_attributes[:rev] }
       before do
@@ -85,21 +96,23 @@ RSpec.describe ForMatchingData, type: :model do
 
     describe '同一の値を設定した RequestDetail と比較すると True が得られる' do
       subject { for_matching_data.compare_attributes == request_detail.compare_attributes }
-      let(:request_application) { create(:request_application, model: create(:model), section: create(:section)) }
 
       let(:request_detail) do
-        create(
+        build(
           :request_detail,
-          request_application: request_application, doc_no: attributes[:doc_no],
-          sht: attributes[:sht], rev: attributes[:rev],
-          eo_chgno: attributes[:eo_chgno], mcl: attributes[:mcl],
-          scp_for_smpl: attributes[:scp_for_smpl], scml_ln: attributes[:scml_ln],
+          doc_no: attributes[:doc_no],
+          sht: attributes[:sht],
+          rev: attributes[:rev],
+          eo_chgno: attributes[:eo_chgno],
+          mcl: attributes[:mcl],
+          scp_for_smpl: attributes[:scp_for_smpl],
+          scml_ln: attributes[:scml_ln],
           doc_type: create(:doc_type, name: attributes[:doc_type]),
           chg_type: create(:chg_type, name: attributes[:chg_type])
         )
       end
 
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
   end
 end

--- a/spec/models/request_detail_spec.rb
+++ b/spec/models/request_detail_spec.rb
@@ -155,4 +155,53 @@ RSpec.describe RequestDetail, type: :model do
       end
     end
   end
+
+  describe 'compare_attributes method' do
+    let(:attributes) do
+      {
+        doc_no: 'DOC-TEST-001',
+        doc_type: 'GHI',
+        sht: 'S01',
+        rev: 'A',
+        eo_chgno: 'N99',
+        chg_type: 'BVSR',
+        mcl: '(D)',
+        scp_for_smpl: 'ｲ-6#2',
+        scml_ln: 'A-N'
+      }
+    end
+
+    let(:request_detail) do
+      create(
+        :request_detail,
+        request_application: request_application, doc_no: attributes[:doc_no],
+        sht: attributes[:sht], rev: attributes[:rev],
+        eo_chgno: attributes[:eo_chgno], mcl: attributes[:mcl],
+        scp_for_smpl: attributes[:scp_for_smpl], scml_ln: attributes[:scml_ln],
+        doc_type: create(:doc_type, name: attributes[:doc_type]),
+        chg_type: create(:chg_type, name: attributes[:chg_type])
+      )
+    end
+
+    describe 'attributesに設定した値が規定のキーと値で返却される' do
+      subject { request_detail.compare_attributes }
+      it { is_expected.to eq attributes }
+    end
+
+    describe '同一の値を設定したForMatchingDataと比較すると True が得られる' do
+      subject { request_detail.compare_attributes == for_matching_data.compare_attributes }
+
+      let(:for_matching_data) do
+        create(
+          :for_matching_data,
+          doc_no: attributes[:doc_no], doc_type_str: attributes[:doc_type],
+          sht: attributes[:sht], eo_chgno: attributes[:eo_chgno],
+          chg_type_str: attributes[:chg_type], mcl: attributes[:mcl],
+          scp_for_smpl: attributes[:scp_for_smpl], scml: attributes[:scml_ln]
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/request_detail_spec.rb
+++ b/spec/models/request_detail_spec.rb
@@ -172,12 +172,15 @@ RSpec.describe RequestDetail, type: :model do
     end
 
     let(:request_detail) do
-      create(
+      build(
         :request_detail,
-        request_application: request_application, doc_no: attributes[:doc_no],
-        sht: attributes[:sht], rev: attributes[:rev],
-        eo_chgno: attributes[:eo_chgno], mcl: attributes[:mcl],
-        scp_for_smpl: attributes[:scp_for_smpl], scml_ln: attributes[:scml_ln],
+        doc_no: attributes[:doc_no],
+        sht: attributes[:sht],
+        rev: attributes[:rev],
+        eo_chgno: attributes[:eo_chgno],
+        mcl: attributes[:mcl],
+        scp_for_smpl: attributes[:scp_for_smpl],
+        scml_ln: attributes[:scml_ln],
         doc_type: create(:doc_type, name: attributes[:doc_type]),
         chg_type: create(:chg_type, name: attributes[:chg_type])
       )
@@ -188,11 +191,22 @@ RSpec.describe RequestDetail, type: :model do
       it { is_expected.to eq attributes }
     end
 
+    describe '値が nil もしくは 空文字 の場合は該当するキーが返却されない' do
+      before do
+        build(:request_detail, doc_no: nil, sht: '')
+      end
+
+      %i(doc_no sht).each do |key|
+        subject { request_detail.compare_attributes.key?(key) }
+        it { is_expected.to be_truthy }
+      end
+    end
+
     describe '同一の値を設定したForMatchingDataと比較すると True が得られる' do
       subject { request_detail.compare_attributes == for_matching_data.compare_attributes }
 
       let(:for_matching_data) do
-        create(
+        build(
           :for_matching_data,
           doc_no: attributes[:doc_no], doc_type_str: attributes[:doc_type],
           sht: attributes[:sht], eo_chgno: attributes[:eo_chgno],
@@ -201,7 +215,7 @@ RSpec.describe RequestDetail, type: :model do
         )
       end
 
-      it { is_expected.to be true }
+      it { is_expected.to be_truthy }
     end
   end
 end


### PR DESCRIPTION
リコンサイル結果のテストコードの前に比較用に生やしたメソッドのテストコードを追加しました。